### PR TITLE
Add a 'remacs-modules' crate for building Emacs/Remacs modules in Rust.

### DIFF
--- a/.travis-format.sh
+++ b/.travis-format.sh
@@ -32,3 +32,6 @@ cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff
 
 cd "$DIR/rust_src/remacs-modules"
 cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff
+
+cd "$DIR/rust_src/remacs-modules/examples"
+cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff

--- a/.travis-format.sh
+++ b/.travis-format.sh
@@ -29,3 +29,6 @@ cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff lib.rs
 
 cd "$DIR/rust_src/alloc_unexecmacosx"
 cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff
+
+cd "$DIR/rust_src/remacs-modules"
+cargo fmt -- --config-path $RUSTFMT_CONFIG_DIR --write-mode=diff

--- a/rust_src/remacs-modules/Cargo.lock
+++ b/rust_src/remacs-modules/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -64,7 +64,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.23"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -135,7 +135,7 @@ name = "memchr"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -195,11 +195,19 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "remacs-modules"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remacs-sys 0.1.0",
+]
+
+[[package]]
 name = "remacs-sys"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -212,7 +220,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -267,7 +275,7 @@ name = "which"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -294,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
 "checksum libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f92926a9a4ba7aeeb01f5fba3f0d577147243b6e7fa8261c219cd1d6fbe3b1c"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"

--- a/rust_src/remacs-modules/Cargo.toml
+++ b/rust_src/remacs-modules/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "remacs-modules"
+version = "0.1.0"
+authors = ["David DeSimone <djd231@scarletmail.rutgers.edu>"]
+
+[lib]
+path = "lib.rs"
+
+
+[dependencies]
+remacs-sys = { version = "0.1.0", path = "../remacs-sys" }
+libc = "0.2"

--- a/rust_src/remacs-modules/examples/Cargo.lock
+++ b/rust_src/remacs-modules/examples/Cargo.lock
@@ -1,0 +1,335 @@
+[[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cexpr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clang-sys"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mymod"
+version = "0.1.0"
+dependencies = [
+ "remacs-modules 0.1.0",
+]
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "remacs-modules"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remacs-sys 0.1.0",
+]
+
+[[package]]
+name = "remacs-sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "which"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
+"checksum bindgen 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57253399c086f4f29e57ffd3b5cdbc23a806a00292619351aa4cfa39cb49d4ea"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbb21df6ff3497a61df5059994297f746267020ba38ce237aad9c875f7b4313"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum clang-sys 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00048189ee171715296dfe3b2fcfd439563c7bfec0d98d3976ce3402d62c8f07"
+"checksum clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc34bf7d5d66268b466b9852bca925ec1d2650654dab4da081e63fd230145c2e"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
+"checksum libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f92926a9a4ba7aeeb01f5fba3f0d577147243b6e7fa8261c219cd1d6fbe3b1c"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6ab4e9218ade5b423358bbd2567d1617418403c7a512603630181813316322"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4be6cfa54dab45266e98b5d7be2f8ce959ddd49abd141a05d52dce4b07f803bb"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/rust_src/remacs-modules/examples/Cargo.toml
+++ b/rust_src/remacs-modules/examples/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mymod"
+version = "0.1.0"
+authors = ["David DeSimone <djd231@scarletmail.rutgers.edu>"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+remacs-modules = { version = "0.1.0", path = "../../remacs-modules" }

--- a/rust_src/remacs-modules/examples/src/lib.rs
+++ b/rust_src/remacs-modules/examples/src/lib.rs
@@ -1,0 +1,26 @@
+extern crate remacs_modules;
+
+use remacs_modules::{EmacsRuntime};
+use std::ptr;
+
+/// The entry point for your module.
+/// For now this need to be #[no_mangle] and extern "C"
+/// Remacs will call this when your module is required.
+#[no_mangle]
+pub extern "C" fn module_init(runtime: EmacsRuntime) -> i32 {
+    let mut env = runtime.get_env();
+    let fun = env.make_function(0, // min args
+                                0, // max args
+                                // You callback, as a boxed closure
+                                Box::new(|env, _args, _user_data| { 
+                                    env.make_integer(43)
+                                }),
+                                "make a number", // docstring
+                                ptr::null_mut() // User data
+    );
+    
+    env.bind("mymod-func", fun); // Bind 'mymod-func' to our created function
+    env.provide("mymod"); // provide our library so we can 'require' it
+
+    0 // Success! 
+}

--- a/rust_src/remacs-modules/examples/src/lib.rs
+++ b/rust_src/remacs-modules/examples/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate remacs_modules;
 
-use remacs_modules::{EmacsRuntime};
-use std::ptr;
+use remacs_modules::EmacsRuntime;
 
 /// The entry point for your module.
 /// For now this need to be #[no_mangle] and extern "C"
@@ -13,18 +12,16 @@ use std::ptr;
 #[no_mangle]
 pub extern "C" fn module_init(runtime: EmacsRuntime) -> i32 {
     let mut env = runtime.get_env();
-    let fun = env.make_function(0, // min args
-                                0, // max args
-                                // You callback, as a boxed closure
-                                Box::new(|env, _args, _user_data| { 
-                                    env.make_integer(43)
-                                }),
-                                "make a number", // docstring
-                                ptr::null_mut() // User data
+    let fun = env.make_function(
+        0, // min args
+        0, // max args
+        // Your callback
+        |env, _args| env.make_integer(43),
+        "make a number", // docstring
     );
-    
+
     env.bind("mymod-func", fun); // Bind 'mymod-func' to our created function
     env.provide("mymod"); // provide our library so we can 'require' it
 
-    0 // Success! 
+    0 // Success!
 }

--- a/rust_src/remacs-modules/examples/src/lib.rs
+++ b/rust_src/remacs-modules/examples/src/lib.rs
@@ -6,6 +6,10 @@ use std::ptr;
 /// The entry point for your module.
 /// For now this need to be #[no_mangle] and extern "C"
 /// Remacs will call this when your module is required.
+/// As a note, Remacs will look for <modname>.so. Cargo likes to name
+/// the produced libs something remacs isn't expecting, so you can either
+/// a) rename the result to <mymod>.so or <mymod>.dll on windows.
+/// b) call (module-load "<cargo name of mymod>")
 #[no_mangle]
 pub extern "C" fn module_init(runtime: EmacsRuntime) -> i32 {
     let mut env = runtime.get_env();

--- a/rust_src/remacs-modules/lib.rs
+++ b/rust_src/remacs-modules/lib.rs
@@ -2,12 +2,12 @@ extern crate libc;
 extern crate remacs_sys;
 
 use remacs_sys::{emacs_env, emacs_runtime, emacs_value};
+use std::ffi::{IntoStringError, NulError};
 use std::ffi::CString;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::slice;
-use std::ffi::{IntoStringError, NulError};
 
 #[repr(C)]
 pub struct EmacsRuntime(*mut emacs_runtime);

--- a/rust_src/remacs-modules/lib.rs
+++ b/rust_src/remacs-modules/lib.rs
@@ -1,0 +1,143 @@
+extern crate remacs_sys;
+extern crate libc;
+
+use remacs_sys::{emacs_runtime, emacs_env, emacs_value};
+use std::ops::{Deref, DerefMut};
+use std::ffi::CString;
+use std::mem;
+use std::slice;
+
+#[repr(C)]
+pub struct EmacsRuntime(*mut emacs_runtime);
+
+#[repr(C)]
+pub struct EmacsEnv(*mut emacs_env);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct EmacsValue(emacs_value);
+
+pub type EmacsInt = ::remacs_sys::EmacsInt;
+
+struct UserData {
+    func: Box<FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>, *mut libc::c_void) -> EmacsValue>,
+    data: *mut libc::c_void,
+}
+
+impl EmacsValue {
+    pub fn to_raw(&self) -> emacs_value {
+        self.0
+    }
+}
+
+impl Deref for EmacsEnv {
+    type Target = emacs_env;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+impl DerefMut for EmacsEnv {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl EmacsRuntime {
+    pub fn get_env(&self) -> EmacsEnv {
+        unsafe {
+            let fnptr = (*self.0).get_environment.unwrap();
+            EmacsEnv((fnptr)(self.0))
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn springboard(env: *mut emacs_env, nargs: libc::ptrdiff_t, args: *mut emacs_value, data: *mut libc::c_void) -> emacs_value {
+    let mut user_data = unsafe { Box::from_raw(data as *mut UserData) };
+    let mut renv = EmacsEnv(env);
+    let slice = unsafe { slice::from_raw_parts_mut(args, nargs as usize) };
+    let mut arr: Vec<EmacsValue> = slice.iter_mut().map(|x| EmacsValue(*x)).collect();
+    let result = {
+        let data = user_data.data;
+        let func = &mut user_data.func;
+        func(&mut renv, &mut arr, data)
+    };
+
+    mem::forget(user_data);
+    result.to_raw()
+}
+
+impl EmacsEnv {
+    pub fn make_function(&mut self,
+                         min_args: isize,
+                         max_args: isize,
+                         func: Box<FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>, *mut libc::c_void) -> EmacsValue>,
+                         docstr: &str,
+                         data: *mut libc::c_void) -> EmacsValue {
+        unsafe {
+            let fnptr = self.make_function.unwrap();
+            let cstring = CString::new(docstr).unwrap();
+            let boxed = Box::new(UserData {
+                func,
+                data,
+            });
+            
+            let result = (fnptr)(self.0,
+                                 min_args,
+                                 max_args,
+                                 Some(springboard),
+                                 cstring.as_ptr(),
+                                 Box::into_raw(boxed) as *mut libc::c_void);
+            EmacsValue(result)
+        }
+    }
+
+    pub fn intern(&mut self, string: &str) -> EmacsValue {
+        let cstring = CString::new(string).unwrap();
+        let fnptr = self.intern.unwrap();
+        EmacsValue(unsafe { (fnptr)(self.0, cstring.as_ptr()) })
+    }
+
+    pub fn provide(&mut self, feature: &str) {
+        let qfeat = self.intern(feature);
+        let qprovide = self.intern("provide");
+        let mut args = vec![qfeat];
+        self.funcall(qprovide, &mut args);
+    }
+
+    pub fn funcall(&mut self, fun: EmacsValue, args: &mut Vec<EmacsValue>) -> EmacsValue {
+        let fnptr = self.funcall.unwrap();
+        let len = args.len() as libc::ptrdiff_t;
+        let mut raw_array: Vec<emacs_value> = args.iter().map(EmacsValue::to_raw).collect();
+        EmacsValue(unsafe { (fnptr)(self.0, fun.to_raw(), len, raw_array.as_mut_ptr()) })
+
+    }
+
+    pub fn bind(&mut self, name: &str, fun: EmacsValue) {
+        let qset = self.intern("fset");
+        let qsym = self.intern(name);
+
+        let mut args = vec![qsym, fun];
+        self.funcall(qset, &mut args);
+    }
+
+    pub fn make_integer(&mut self, num: EmacsInt) -> EmacsValue {
+        let fnptr = self.make_integer.unwrap();
+        EmacsValue(unsafe { (fnptr)(self.0, num) })
+    }
+}
+
+extern "C" {
+    fn module_init (runtime: EmacsRuntime) -> i32;
+}
+
+#[no_mangle]
+pub extern "C" fn emacs_module_init(ert: *mut emacs_runtime) -> libc::c_int {
+    let runtime = EmacsRuntime(ert);
+    unsafe { module_init(runtime) as libc::c_int }
+}
+
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static plugin_is_GPL_compatible: i32 = 0;

--- a/rust_src/remacs-modules/lib.rs
+++ b/rust_src/remacs-modules/lib.rs
@@ -1,11 +1,14 @@
-extern crate remacs_sys;
 extern crate libc;
+extern crate remacs_sys;
 
-use remacs_sys::{emacs_runtime, emacs_env, emacs_value};
-use std::ops::{Deref, DerefMut};
+use remacs_sys::{emacs_env, emacs_runtime, emacs_value};
 use std::ffi::CString;
 use std::mem;
+use std::ops::{Deref, DerefMut};
 use std::slice;
+//use std::ptr;
+//use std::io::{Error, ErrorKind};
+//use std::ffi::IntoStringError;
 
 #[repr(C)]
 pub struct EmacsRuntime(*mut emacs_runtime);
@@ -18,10 +21,20 @@ pub struct EmacsEnv(*mut emacs_env);
 pub struct EmacsValue(emacs_value);
 
 pub type EmacsInt = ::remacs_sys::EmacsInt;
+pub type FuncallExit = ::remacs_sys::emacs_funcall_exit;
+#[allow(non_camel_case_types)]
+pub type intmax_t = ::libc::intmax_t;
 
 struct UserData {
-    func: Box<FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>, *mut libc::c_void) -> EmacsValue>,
-    data: *mut libc::c_void,
+    func: Box<FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>) -> EmacsValue>,
+}
+
+macro_rules! call {
+    ($self: ident, $func: ident) => (call!($self, $func,));
+    ($self: ident, $func: ident, $($arg:expr),*) => {{
+        let fnptr = $self.$func.unwrap();
+        unsafe { (fnptr)($self.0, $($arg),*) }
+    }}
 }
 
 impl EmacsValue {
@@ -43,25 +56,39 @@ impl DerefMut for EmacsEnv {
     }
 }
 
+impl Deref for EmacsRuntime {
+    type Target = emacs_runtime;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+impl DerefMut for EmacsRuntime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.0 }
+    }
+}
+
 impl EmacsRuntime {
     pub fn get_env(&self) -> EmacsEnv {
-        unsafe {
-            let fnptr = (*self.0).get_environment.unwrap();
-            EmacsEnv((fnptr)(self.0))
-        }
+        EmacsEnv(call!(self, get_environment))
     }
 }
 
 #[no_mangle]
-pub extern "C" fn springboard(env: *mut emacs_env, nargs: libc::ptrdiff_t, args: *mut emacs_value, data: *mut libc::c_void) -> emacs_value {
+pub extern "C" fn springboard(
+    env: *mut emacs_env,
+    nargs: libc::ptrdiff_t,
+    args: *mut emacs_value,
+    data: *mut libc::c_void,
+) -> emacs_value {
     let mut user_data = unsafe { Box::from_raw(data as *mut UserData) };
     let mut renv = EmacsEnv(env);
     let slice = unsafe { slice::from_raw_parts_mut(args, nargs as usize) };
     let mut arr: Vec<EmacsValue> = slice.iter_mut().map(|x| EmacsValue(*x)).collect();
     let result = {
-        let data = user_data.data;
         let func = &mut user_data.func;
-        func(&mut renv, &mut arr, data)
+        func(&mut renv, &mut arr)
     };
 
     mem::forget(user_data);
@@ -69,34 +96,37 @@ pub extern "C" fn springboard(env: *mut emacs_env, nargs: libc::ptrdiff_t, args:
 }
 
 impl EmacsEnv {
-    pub fn make_function(&mut self,
-                         min_args: isize,
-                         max_args: isize,
-                         func: Box<FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>, *mut libc::c_void) -> EmacsValue>,
-                         docstr: &str,
-                         data: *mut libc::c_void) -> EmacsValue {
+    pub fn make_function<T: 'static>(
+        &mut self,
+        min_args: isize,
+        max_args: isize,
+        func: T,
+        docstr: &str,
+    ) -> EmacsValue
+    where
+        T: FnMut(&mut EmacsEnv, &mut Vec<EmacsValue>) -> EmacsValue + Sized,
+    {
         unsafe {
             let fnptr = self.make_function.unwrap();
             let cstring = CString::new(docstr).unwrap();
             let boxed = Box::new(UserData {
-                func,
-                data,
+                func: Box::new(func),
             });
-            
-            let result = (fnptr)(self.0,
-                                 min_args,
-                                 max_args,
-                                 Some(springboard),
-                                 cstring.as_ptr() as *mut libc::c_char,
-                                 Box::into_raw(boxed) as *mut libc::c_void);
+            let result = (fnptr)(
+                self.0,
+                min_args,
+                max_args,
+                Some(springboard),
+                cstring.as_ptr() as *mut libc::c_char,
+                Box::into_raw(boxed) as *mut libc::c_void,
+            );
             EmacsValue(result)
         }
     }
 
     pub fn intern(&mut self, string: &str) -> EmacsValue {
         let cstring = CString::new(string).unwrap();
-        let fnptr = self.intern.unwrap();
-        EmacsValue(unsafe { (fnptr)(self.0, cstring.as_ptr() as *mut libc::c_char) })
+        EmacsValue(call!(self, intern, cstring.as_ptr() as *mut libc::c_char))
     }
 
     pub fn provide(&mut self, feature: &str) {
@@ -107,11 +137,15 @@ impl EmacsEnv {
     }
 
     pub fn funcall(&mut self, fun: EmacsValue, args: &mut Vec<EmacsValue>) -> EmacsValue {
-        let fnptr = self.funcall.unwrap();
         let len = args.len() as libc::ptrdiff_t;
         let mut raw_array: Vec<emacs_value> = args.iter().map(EmacsValue::to_raw).collect();
-        EmacsValue(unsafe { (fnptr)(self.0, fun.to_raw(), len, raw_array.as_mut_ptr()) })
-
+        EmacsValue(call!(
+            self,
+            funcall,
+            fun.to_raw(),
+            len,
+            raw_array.as_mut_ptr()
+        ))
     }
 
     pub fn bind(&mut self, name: &str, fun: EmacsValue) {
@@ -123,13 +157,130 @@ impl EmacsEnv {
     }
 
     pub fn make_integer(&mut self, num: EmacsInt) -> EmacsValue {
-        let fnptr = self.make_integer.unwrap();
-        EmacsValue(unsafe { (fnptr)(self.0, num) })
+        EmacsValue(call!(self, make_integer, num))
+    }
+
+    pub fn make_global_ref(&mut self, any_reference: EmacsValue) -> EmacsValue {
+        EmacsValue(call!(self, make_global_ref, any_reference.to_raw()))
+    }
+
+    pub fn free_global_ref(&mut self, global_reference: EmacsValue) {
+        call!(self, free_global_ref, global_reference.to_raw());
+    }
+
+    pub fn non_local_exit_check(&mut self) -> FuncallExit {
+        call!(self, non_local_exit_check)
+    }
+
+    pub fn non_local_exit_clear(&mut self) {
+        call!(self, non_local_exit_clear);
+    }
+
+    pub fn non_local_exit_get(&mut self) -> (FuncallExit, EmacsValue, EmacsValue) {
+        let mut non_local_exit_symbol_out = 0 as emacs_value;
+        let mut non_local_exit_data_out = 0 as emacs_value;
+        let result = call!(
+            self,
+            non_local_exit_get,
+            &mut non_local_exit_symbol_out,
+            &mut non_local_exit_data_out
+        );
+
+        (
+            result,
+            EmacsValue(non_local_exit_symbol_out),
+            EmacsValue(non_local_exit_data_out),
+        )
+    }
+
+    pub fn non_local_exit_signal(
+        &mut self,
+        non_local_exit_symbol: EmacsValue,
+        non_local_exit_data: EmacsValue,
+    ) {
+        call!(
+            self,
+            non_local_exit_signal,
+            non_local_exit_symbol.to_raw(),
+            non_local_exit_data.to_raw()
+        );
+    }
+
+    pub fn non_local_exit_throw(&mut self, tag: EmacsValue, value: EmacsValue) {
+        call!(self, non_local_exit_throw, tag.to_raw(), value.to_raw());
+    }
+
+    pub fn type_of(&self, value: EmacsValue) -> EmacsValue {
+        EmacsValue(call!(self, type_of, value.to_raw()))
+    }
+
+    pub fn is_not_nil(&self, value: EmacsValue) -> bool {
+        call!(self, is_not_nil, value.to_raw())
+    }
+
+    pub fn eq(&self, a: EmacsValue, b: EmacsValue) -> bool {
+        call!(self, eq, a.to_raw(), b.to_raw())
+    }
+
+    pub fn extract_integer(&self, value: EmacsValue) -> intmax_t {
+        call!(self, extract_integer, value.to_raw())
+    }
+
+    pub fn extract_float(&self, value: EmacsValue) -> f64 {
+        call!(self, extract_float, value.to_raw())
+    }
+
+    pub fn make_float(&mut self, value: f64) -> EmacsValue {
+        EmacsValue(call!(self, make_float, value))
+    }
+
+    // pub fn copy_string_contents(&self, value: EmacsValue)
+    //                             -> Result<String, > {
+    //     let required_size;
+    //     let result = call!(self,
+    //                        copy_string_contents,
+    //                        value.to_raw(),
+    //                        ptr::null_mut(),
+    //                        &mut required_size);
+    //     // if !result {
+    //     //     return Err(Error::new(ErrorKind::Other, "value is not a proper string"));
+    //     // }
+
+    //     let mut buffer: Vec<u8> = Vec::with_capacity(required_size as usize);
+    //     let second_result = call!(self,
+    //                               copy_string_contents,
+    //                               value.to_raw(),
+    //                               buffer.as_mut_ptr() as *mut libc::c_char,
+    //                               &mut required_size);
+    //     // if !second_result {
+    //     //     return Err(Error::new(ErrorKind::Other, "failed to copy string."));
+    //     // }
+
+    //     CString::new(buffer)?.into_string()?
+    // }
+
+    pub fn make_string(&mut self, string: &str) -> EmacsValue {
+        let cstring = CString::new(string).unwrap();
+        let len = cstring.to_bytes().len() as isize;
+        let ptr = cstring.as_ptr() as *mut libc::c_char;
+        EmacsValue(call!(self, make_string, ptr, len))
+    }
+
+    pub fn vec_get(&self, vec: EmacsValue, i: isize) -> EmacsValue {
+        EmacsValue(call!(self, vec_get, vec.to_raw(), i))
+    }
+
+    pub fn vec_set(&mut self, vec: EmacsValue, i: isize, val: EmacsValue) {
+        call!(self, vec_set, vec.to_raw(), i, val.to_raw())
+    }
+
+    pub fn vec_size(&self, vec: EmacsValue) -> isize {
+        call!(self, vec_size, vec.to_raw())
     }
 }
 
 extern "C" {
-    fn module_init (runtime: EmacsRuntime) -> i32;
+    fn module_init(runtime: EmacsRuntime) -> i32;
 }
 
 #[no_mangle]

--- a/rust_src/remacs-modules/lib.rs
+++ b/rust_src/remacs-modules/lib.rs
@@ -87,7 +87,7 @@ impl EmacsEnv {
                                  min_args,
                                  max_args,
                                  Some(springboard),
-                                 cstring.as_ptr(),
+                                 cstring.as_ptr() as *mut libc::c_char,
                                  Box::into_raw(boxed) as *mut libc::c_void);
             EmacsValue(result)
         }
@@ -96,7 +96,7 @@ impl EmacsEnv {
     pub fn intern(&mut self, string: &str) -> EmacsValue {
         let cstring = CString::new(string).unwrap();
         let fnptr = self.intern.unwrap();
-        EmacsValue(unsafe { (fnptr)(self.0, cstring.as_ptr()) })
+        EmacsValue(unsafe { (fnptr)(self.0, cstring.as_ptr() as *mut libc::c_char) })
     }
 
     pub fn provide(&mut self, feature: &str) {

--- a/rust_src/remacs-sys/Cargo.toml
+++ b/rust_src/remacs-sys/Cargo.toml
@@ -11,3 +11,4 @@ libc = "0.2"
 
 [build-dependencies]
 libc = "0.2"
+bindgen = "0.31.0"

--- a/rust_src/remacs-sys/build.rs
+++ b/rust_src/remacs-sys/build.rs
@@ -198,12 +198,21 @@ fn generate_globals() {
 }
 
 fn generate_module_code() {
-    let builder = bindgen::Builder::default()
+    let mut builder = bindgen::Builder::default()
         .rust_target(bindgen::RustTarget::Nightly)
         .generate_comments(true)
         .header("../../src/emacs-module.h")
         .rustified_enum("emacs_funcall_exit")
         .ctypes_prefix("::libc");
+
+    if cfg!(windows) {
+        builder = builder
+            .clang_arg("-fms-extensions")
+            .clang_arg("-fms-compatibility")
+            .clang_arg("-fms-compatibility-version=19")
+            .clang_arg("-D_MSC_VER=1900")
+            .clang_arg("-D_M_X64")
+    }
 
     let bindings = builder
         .rustfmt_bindings(true)

--- a/rust_src/remacs-sys/build.rs
+++ b/rust_src/remacs-sys/build.rs
@@ -1,5 +1,5 @@
-extern crate libc;
 extern crate bindgen;
+extern crate libc;
 
 use std::cmp::max;
 use std::env;
@@ -213,10 +213,7 @@ fn generate_module_code() {
     let source = bindings.to_string();
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("modules.rs");
     let file = File::create(out_path);
-    file.unwrap()
-        .write_all(source.as_bytes())
-        .unwrap();
-
+    file.unwrap().write_all(source.as_bytes()).unwrap();
 }
 
 fn main() {

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -20,8 +20,8 @@ extern crate libc;
 
 pub mod libm;
 
-use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, off_t, ptrdiff_t,
-           size_t, time_t, timespec};
+use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, off_t, ptrdiff_t, size_t,
+           time_t, timespec};
 
 // libc prefers not to merge pid_t as an alias for c_int in Windows, so we will not use libc::pid_t
 // and alias it ourselves.

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -20,7 +20,7 @@ extern crate libc;
 
 pub mod libm;
 
-use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, intmax_t, off_t, ptrdiff_t,
+use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, off_t, ptrdiff_t,
            size_t, time_t, timespec};
 
 // libc prefers not to merge pid_t as an alias for c_int in Windows, so we will not use libc::pid_t
@@ -31,6 +31,7 @@ pub type Lisp_Object = EmacsInt;
 
 include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
 include!(concat!(env!("OUT_DIR"), "/globals.rs"));
+include!(concat!(env!("OUT_DIR"), "/modules.rs"));
 
 pub type char_bits = u32;
 pub const CHAR_ALT: char_bits = 0x0400000;


### PR DESCRIPTION
I recently verified https://github.com/Wilfred/remacs/issues/464, by writing a small basic C module. It worked, but it got me thinking about writing emacs/remacs modules in Rust. In order to make this easier, I made a Rust crate that wraps the types provided by emacs-modules.h. The idea is that this crate can be used by emacs modules as a dependency. The good news is that these modules should be usable by both emacs AND remacs, so this can be useful for people who want to write modules in Rust but want them to work for both platforms. 

I decided to use `bindgen` to generate the code for emacs-modules.h. I like the idea of using bindgen where we can, and emacs-modules.h is fairly self contained. 

Some notes:

On OSX, Cargo produces .dylibs. By default, the shared_lib extension in remacs is .so on OSX. This can be changed, or you can work around it by manually calling (module-load "\<name\>"), but it is a little annoying.  