### PR TITLE
[WIP] Port get-buffer-create

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -934,6 +934,19 @@ pub fn buffer_base_buffer(buffer: LispObject) -> Option<LispBufferRef> {
     buffer.as_buffer_or_current_buffer().base_buffer()
 }
 
+/// Return the buffer specified by BUFFER-OR-NAME, creating a new one if needed.
+/// If BUFFER-OR-NAME is a string and a live buffer with that name exists,
+/// return that buffer.  If no such buffer exists, create a new buffer with
+/// that name and return it.  If BUFFER-OR-NAME starts with a space, the new
+/// buffer does not keep undo information.
+
+/// If BUFFER-OR-NAME is a buffer instead of a string, return it as given,
+/// even if it is dead.  The return value is never nil.
+#[lisp_fn]
+pub fn get_buffer_create(buffer_or_name: LispObject) -> LispBufferRef {
+    LispBufferRef::create_new(buffer_or_name)
+}
+
 #[no_mangle]
 pub extern "C" fn rust_syms_of_buffer() {
     def_lisp_sym!(Qget_file_buffer, "get-file-buffer");

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -345,7 +345,7 @@ impl LispBufferRef {
         if name.len_chars() == 0 {
             error!("Empty string for buffer name is not allowed");
         }
-        let b = unsafe { &mut (*allocate_buffer()) };
+        let mut b = unsafe { ExternalPtr::new(allocate_buffer()) };
         /* An ordinary buffer uses its own struct buffer_text.  */
         b.text = &mut b.own_text;
         b.base_buffer = ptr::null_mut();
@@ -358,8 +358,23 @@ impl LispBufferRef {
         let buffer_text = unsafe { &mut (*b.text) };
         buffer_text.gap_size = initial_gap_size;
 
-        let c: *mut Lisp_Buffer = b;
-        ExternalPtr::new(c)
+        // TODO: Bring in buffer text allocation code
+
+        let beg = 1;
+        let beg_byte = 1;
+        b.set_pt_both(beg, beg_byte);
+        b.set_begv_both(beg, beg_byte);
+        b.set_zv_both(beg, beg_byte);
+        buffer_text.gpt = beg;
+        buffer_text.gpt_byte = beg_byte;
+        buffer_text.z = beg;
+        buffer_text.z_byte = beg_byte;
+        buffer_text.modiff = 1;
+        buffer_text.overlay_modiff = 1;
+        buffer_text.save_modiff = 1;
+        buffer_text.compact = 1;
+
+        b
     }
 }
 

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -488,16 +488,16 @@ fn sha512_buffer(buffer: &[u8], dest_buf: &mut [u8]) {
 /// disregarding any coding systems.  If nil, use the current buffer.
 #[lisp_fn(min = "0")]
 pub fn buffer_hash(buffer_or_name: LispObject) -> LispObject {
-    let buffer = if buffer_or_name.is_nil() {
+    let b = if buffer_or_name.is_nil() {
         current_buffer()
     } else {
-        get_buffer(buffer_or_name)
+        let b = get_buffer(buffer_or_name);
+        if b.is_nil() {
+            nsberror(buffer_or_name.to_raw());
+        }
+        b.as_buffer_or_error()
     };
 
-    if buffer.is_nil() {
-        nsberror(buffer_or_name.to_raw());
-    }
-    let b = buffer.as_buffer().unwrap();
     let mut ctx = sha1::Sha1::new();
 
     ctx.update(unsafe {

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -15,7 +15,7 @@ use lists::memq;
 #[lisp_fn(min = "0")]
 pub fn minibufferp(object: LispObject) -> bool {
     let buffer = if object.is_nil() {
-        current_buffer()
+        current_buffer().as_lisp_obj()
     } else if object.is_string() {
         get_buffer(object)
     } else {

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -38,8 +38,8 @@ use std::slice;
 
 use libc::{c_char, c_int, c_uchar, c_uint, c_void, memset, ptrdiff_t, size_t};
 
-use remacs_sys::{EmacsInt, Lisp_String, Lisp_Type, CHARACTERBITS, CHAR_CTL, CHAR_MODIFIER_MASK,
-                 CHAR_SHIFT};
+use remacs_sys::{EmacsInt, Lisp_Interval, Lisp_String, Lisp_Type, CHARACTERBITS, CHAR_CTL,
+                 CHAR_MODIFIER_MASK, CHAR_SHIFT};
 use remacs_sys::emacs_abort;
 
 use lisp::{ExternalPtr, LispObject};
@@ -159,6 +159,10 @@ impl LispStringRef {
 
     pub fn set_byte(&mut self, idx: ptrdiff_t, elt: c_uchar) {
         unsafe { ptr::write(self.data_ptr().offset(idx), elt) };
+    }
+
+    pub fn set_intervals(&mut self, interval: *mut Lisp_Interval) {
+        self.intervals = interval;
     }
 }
 

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -3620,6 +3620,7 @@ extern "C" {
 
     pub fn pset_childp(p: *mut Lisp_Process, val: LispObject);
     pub fn allocate_buffer() -> *mut Lisp_Buffer;
+    pub fn nconc2(s1: LispObject, s2: LispObject) -> LispObject;
 }
 
 /// Contains C definitions from the font.h header.

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -3621,6 +3621,10 @@ extern "C" {
     pub fn pset_childp(p: *mut Lisp_Process, val: LispObject);
     pub fn allocate_buffer() -> *mut Lisp_Buffer;
     pub fn nconc2(s1: LispObject, s2: LispObject) -> LispObject;
+    pub fn block_input();
+    pub fn unblock_input();
+    pub fn alloc_buffer_text(pointer: *mut Lisp_Buffer, nbytes: ptrdiff_t);
+    pub fn buffer_memory_full(nbytes: ptrdiff_t);
 }
 
 /// Contains C definitions from the font.h header.

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -3572,6 +3572,7 @@ extern "C" {
     pub fn pset_sentinel(p: *mut Lisp_Process, val: LispObject);
 
     pub fn pset_childp(p: *mut Lisp_Process, val: LispObject);
+    pub fn allocate_buffer() -> *mut Lisp_Buffer;
 }
 
 /// Contains C definitions from the font.h header.

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -230,7 +230,7 @@ pub struct Lisp_String {
     // TODO: Use correct definition for this.
     //
     // Maybe use rust nightly unions?
-    pub intervals: *mut c_void, // @TODO implement
+    pub intervals: *mut Lisp_Interval,
     pub data: *mut c_char,
 }
 
@@ -1031,7 +1031,7 @@ pub struct Lisp_Buffer {
     overlays_after: *mut c_void,
     overlay_center: ptrdiff_t,
 
-    undo_list: LispObject,
+    pub undo_list: LispObject,
 }
 
 extern "C" {

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -3625,6 +3625,8 @@ extern "C" {
     pub fn unblock_input();
     pub fn alloc_buffer_text(pointer: *mut Lisp_Buffer, nbytes: ptrdiff_t);
     pub fn buffer_memory_full(nbytes: ptrdiff_t);
+    pub fn reset_buffer(b: *mut Lisp_Buffer);
+    pub fn reset_buffer_local_variables(b: *mut Lisp_Buffer, permanent_too: bool);
 }
 
 /// Contains C definitions from the font.h header.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -109,7 +109,7 @@ static void call_overlay_mod_hooks (Lisp_Object list, Lisp_Object overlay,
                                     bool after, Lisp_Object arg1,
                                     Lisp_Object arg2, Lisp_Object arg3);
 static void swap_out_buffer_local_variables (struct buffer *b);
-static void reset_buffer_local_variables (struct buffer *, bool);
+void reset_buffer_local_variables (struct buffer *, bool);
 
 /* Alist of all buffer names vs the buffers.  This used to be
    a Lisp-visible variable, but is no longer, to prevent lossage
@@ -118,7 +118,7 @@ Lisp_Object Vbuffer_alist;
 
 static Lisp_Object QSFundamental;	/* A string "Fundamental".  */
 
-static void alloc_buffer_text (struct buffer *, ptrdiff_t);
+void alloc_buffer_text (struct buffer *, ptrdiff_t);
 static void free_buffer_text (struct buffer *b);
 static struct Lisp_Overlay * copy_overlays (struct buffer *, struct Lisp_Overlay *);
 static void modify_overlay (struct buffer *, ptrdiff_t, ptrdiff_t);
@@ -369,106 +369,6 @@ bset_zv_marker (struct buffer *b, Lisp_Object val)
 }
 
 
-DEFUN ("get-buffer-create", Fget_buffer_create, Sget_buffer_create, 1, 1, 0,
-       doc: /* Return the buffer specified by BUFFER-OR-NAME, creating a new one if needed.
-If BUFFER-OR-NAME is a string and a live buffer with that name exists,
-return that buffer.  If no such buffer exists, create a new buffer with
-that name and return it.  If BUFFER-OR-NAME starts with a space, the new
-buffer does not keep undo information.
-
-If BUFFER-OR-NAME is a buffer instead of a string, return it as given,
-even if it is dead.  The return value is never nil.  */)
-  (register Lisp_Object buffer_or_name)
-{
-  register Lisp_Object buffer, name;
-  register struct buffer *b;
-
-  buffer = Fget_buffer (buffer_or_name);
-  if (!NILP (buffer))
-    return buffer;
-
-  if (SCHARS (buffer_or_name) == 0)
-    error ("Empty string for buffer name is not allowed");
-
-  b = allocate_buffer ();
-
-  /* An ordinary buffer uses its own struct buffer_text.  */
-  b->text = &b->own_text;
-  b->base_buffer = NULL;
-  /* No one shares the text with us now.  */
-  b->indirections = 0;
-  /* No one shows us now.  */
-  b->window_count = 0;
-
-  BUF_GAP_SIZE (b) = 20;
-  block_input ();
-  /* We allocate extra 1-byte at the tail and keep it always '\0' for
-     anchoring a search.  */
-  alloc_buffer_text (b, BUF_GAP_SIZE (b) + 1);
-  unblock_input ();
-  if (! BUF_BEG_ADDR (b))
-    buffer_memory_full (BUF_GAP_SIZE (b) + 1);
-
-  b->pt = BEG;
-  b->begv = BEG;
-  b->zv = BEG;
-  b->pt_byte = BEG_BYTE;
-  b->begv_byte = BEG_BYTE;
-  b->zv_byte = BEG_BYTE;
-
-  BUF_GPT (b) = BEG;
-  BUF_GPT_BYTE (b) = BEG_BYTE;
-
-  BUF_Z (b) = BEG;
-  BUF_Z_BYTE (b) = BEG_BYTE;
-  BUF_MODIFF (b) = 1;
-  BUF_CHARS_MODIFF (b) = 1;
-  BUF_OVERLAY_MODIFF (b) = 1;
-  BUF_SAVE_MODIFF (b) = 1;
-  BUF_COMPACT (b) = 1;
-  set_buffer_intervals (b, NULL);
-  BUF_UNCHANGED_MODIFIED (b) = 1;
-  BUF_OVERLAY_UNCHANGED_MODIFIED (b) = 1;
-  BUF_END_UNCHANGED (b) = 0;
-  BUF_BEG_UNCHANGED (b) = 0;
-  *(BUF_GPT_ADDR (b)) = *(BUF_Z_ADDR (b)) = 0; /* Put an anchor '\0'.  */
-  b->text->inhibit_shrinking = false;
-  b->text->redisplay = false;
-
-  b->newline_cache = 0;
-  b->width_run_cache = 0;
-  b->bidi_paragraph_cache = 0;
-  bset_width_table (b, Qnil);
-  b->prevent_redisplay_optimizations_p = 1;
-
-  /* An ordinary buffer normally doesn't need markers
-     to handle BEGV and ZV.  */
-  bset_pt_marker (b, Qnil);
-  bset_begv_marker (b, Qnil);
-  bset_zv_marker (b, Qnil);
-
-  name = Fcopy_sequence (buffer_or_name);
-  set_string_intervals (name, NULL);
-  bset_name (b, name);
-
-  bset_undo_list (b, SREF (name, 0) != ' ' ? Qnil : Qt);
-
-  reset_buffer (b);
-  reset_buffer_local_variables (b, 1);
-
-  bset_mark (b, Fmake_marker ());
-  BUF_MARKERS (b) = NULL;
-
-  /* Put this in the alist of all live buffers.  */
-  XSETBUFFER (buffer, b);
-  Vbuffer_alist = nconc2 (Vbuffer_alist, list1 (Fcons (name, buffer)));
-  /* And run buffer-list-update-hook.  */
-  if (!NILP (Vrun_hooks))
-    call1 (Vrun_hooks, Qbuffer_list_update_hook);
-
-  return buffer;
-}
-
 
 /* Return a list of overlays which is a copy of the overlay list
    LIST, but for buffer B.  */
@@ -787,7 +687,7 @@ reset_buffer (register struct buffer *b)
    If PERMANENT_TOO, reset permanent buffer-local variables.
    If not, preserve those.  */
 
-static void
+void
 reset_buffer_local_variables (struct buffer *b, bool permanent_too)
 {
   int offset, i;
@@ -4610,7 +4510,7 @@ mmap_realloc (void **var, size_t nbytes)
 
 /* Allocate NBYTES bytes for buffer B's text buffer.  */
 
-static void
+void
 alloc_buffer_text (struct buffer *b, ptrdiff_t nbytes)
 {
   void *p;
@@ -5876,7 +5776,6 @@ Functions running this hook are, `get-buffer-create',
   Vbuffer_list_update_hook = Qnil;
   DEFSYM (Qbuffer_list_update_hook, "buffer-list-update-hook");
 
-  defsubr (&Sget_buffer_create);
   defsubr (&Smake_indirect_buffer);
   defsubr (&Sgenerate_new_buffer_name);
   defsubr (&Sbuffer_local_variables);

--- a/test/rust_src/src/buffers-tests.el
+++ b/test/rust_src/src/buffers-tests.el
@@ -21,3 +21,16 @@
     (should (null (overlay-properties overlay)))
     (overlay-put overlay 'priority 2)
     (should (equal (overlay-properties overlay) '(priority 2)))))
+
+(ert-deftest test-get-buffer-create ()
+  (should-error (eval '(get-buffer-create 23)) :type 'wrong-type-argument)
+  (should-error (eval '(get-buffer-create nil)) :type 'wrong-type-argument)
+  (let* ((new-name (generate-new-buffer-name "start"))
+         (generated-buffer (generate-new-buffer new-name)))
+    ;; Function call with a non-existing buffer name
+    (should (bufferp generated-buffer))
+    ;; Function call with a buffer
+    (should (eq generated-buffer (get-buffer-create generated-buffer)))
+    ;; Function call with an existing buffer name
+    (should (eq generated-buffer (get-buffer-create new-name)))))
+    


### PR DESCRIPTION
Ports `get-buffer-create`. I didn't port the functions `reset_buffer` and `reset_buffer_local_variables` as the branch became bigger than I expected.

Pending questions:

- I couldn't understand what `XSETBUFFER (buffer, b);` (line no. 463 in `buffer.c) does.
- Why are the `bool_bf` fields in `Lisp_Buffer` and `Lisp_Buffer_Text` combined to a single `flags` member? At least temporarily, I put the fields as they are in C code.

I guess because of the above, the code doesn't compile now.

Other changes:
- Introduced `Lisp_Interval` type
- Made `buffers::current_buffer()` return a `LispBufferRef` as opposed to a `LispObject`

