### PR TITLE
Refactor validate region

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -8,7 +8,7 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     base64_crate,
-    buffers::validate_region,
+    buffers::validate_region_rust,
     lisp::LispObject,
     marker::buf_charpos_to_bytepos,
     multibyte::{multibyte_char_at, raw_byte_from_codepoint, LispStringRef, MAX_5_BYTE_CHAR},
@@ -269,21 +269,15 @@ pub fn base64_decode_string(string: LispStringRef) -> LispObject {
 /// Base64-encode the region between BEG and END. Return the length of the encoded text. Optional
 /// third argument NO-LINE-BREAK means do not break long lines into shorter lines.
 #[lisp_fn(min = "2", intspec = "r")]
-pub fn base64_encode_region(
-    mut beg: LispObject,
-    mut end: LispObject,
-    no_line_break: bool,
-) -> EmacsInt {
-    unsafe { validate_region(&mut beg, &mut end) };
+pub fn base64_encode_region(beg: LispObject, end: LispObject, no_line_break: bool) -> EmacsInt {
+    let (beg, end) = validate_region_rust(beg, end);
     let mut current_buffer = ThreadState::current_buffer_unchecked();
     let old_pos = current_buffer.pt;
 
-    let ibeg = beg.as_natnum_or_error() as isize;
-    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), ibeg);
-    let iend = end.as_natnum_or_error() as isize;
-    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), iend);
+    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), beg);
+    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), end);
 
-    unsafe { move_gap_both(ibeg, begpos) };
+    unsafe { move_gap_both(beg, begpos) };
 
     // Allocate room for the extra 33% plus newlines
     let length = (endpos - begpos) as usize;
@@ -298,15 +292,15 @@ pub fn base64_encode_region(
 
     // We now insert the new contents and delete the old in the region
     unsafe {
-        set_point_both(begpos, ibeg);
+        set_point_both(begpos, beg);
         insert(encoded.as_ptr() as *const c_char, encoded_length);
         del_range_byte(begpos + encoded_length, endpos + encoded_length);
     }
 
-    let pos_to_set = if old_pos >= iend {
-        old_pos + encoded_length - (iend - ibeg)
-    } else if old_pos > ibeg {
-        old_pos - ibeg
+    let pos_to_set = if old_pos >= end {
+        old_pos + encoded_length - (end - beg)
+    } else if old_pos > beg {
+        old_pos - beg
     } else {
         old_pos
     };
@@ -316,16 +310,14 @@ pub fn base64_encode_region(
 }
 
 #[lisp_fn(intspec = "r")]
-pub fn base64_decode_region(mut beg: LispObject, mut end: LispObject) -> EmacsInt {
-    unsafe { validate_region(&mut beg, &mut end) };
+pub fn base64_decode_region(beg: LispObject, end: LispObject) -> EmacsInt {
+    let (beg, end) = validate_region_rust(beg, end);
 
     let mut current_buffer = ThreadState::current_buffer_unchecked();
     let mut old_pos = current_buffer.pt;
 
-    let ibeg = beg.as_natnum_or_error() as isize;
-    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), ibeg);
-    let iend = end.as_natnum_or_error() as isize;
-    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), iend);
+    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), beg);
+    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), end);
 
     let multibyte = current_buffer.multibyte_characters_enabled();
     let length = (endpos - begpos) as usize;
@@ -341,7 +333,7 @@ pub fn base64_decode_region(mut beg: LispObject, mut end: LispObject) -> EmacsIn
 
     // We've decoded it so insert the new contents and delete the old.
     unsafe {
-        temp_set_point_both(current_buffer.as_mut(), ibeg, begpos);
+        temp_set_point_both(current_buffer.as_mut(), beg, begpos);
         insert_1_both(
             decoded.as_ptr() as *const c_char,
             inserted_chars,
@@ -350,20 +342,20 @@ pub fn base64_decode_region(mut beg: LispObject, mut end: LispObject) -> EmacsIn
             true,
             false,
         );
-        signal_after_change(ibeg, 0, inserted_chars);
+        signal_after_change(beg, 0, inserted_chars);
         del_range_both(
             current_buffer.pt,
             current_buffer.pt_byte,
-            iend + inserted_chars,
+            end + inserted_chars,
             endpos + decoded_length,
             true,
         );
     }
 
-    if old_pos >= iend {
-        old_pos += inserted_chars - (iend - ibeg);
-    } else if old_pos > ibeg {
-        old_pos = ibeg;
+    if old_pos >= end {
+        old_pos += inserted_chars - (end - beg);
+    } else if old_pos > beg {
+        old_pos = beg;
     }
     unsafe { set_point(max(current_buffer.zv, old_pos)) };
 

--- a/rust_src/src/decompress.rs
+++ b/rust_src/src/decompress.rs
@@ -7,7 +7,7 @@ use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use remacs_macros::lisp_fn;
 
 use crate::{
-    buffers::validate_region,
+    buffers::validate_region_rust,
     lisp::LispObject,
     remacs_sys::{
         buf_charpos_to_bytepos, del_range_2, insert_from_gap, make_gap, maybe_quit, modify_text,
@@ -40,8 +40,8 @@ fn create_buffer_decoder<'a>(buffer: &'a [u8]) -> Box<Read + 'a> {
 /// On failure, return nil and leave the data in place.
 /// This function can be called only in unibyte buffers.
 #[lisp_fn]
-pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> bool {
-    unsafe { validate_region(&mut start, &mut end) };
+pub fn zlib_decompress_region(start: LispObject, end: LispObject) -> bool {
+    let (start, end) = validate_region_rust(start, end);
 
     let mut current_buffer = ThreadState::current_buffer_unchecked();
 
@@ -49,32 +49,26 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
         error!("This function can be called only in unibyte buffers");
     };
 
-    let istart = start.as_fixnum_or_error() as isize;
-    let iend = end.as_fixnum_or_error() as isize;
-
     // Empty region, decompress failed.
-    if istart == iend {
+    if start == end {
         return false;
     }
 
     unsafe {
         // Do the following before manipulating the gap.
-        modify_text(istart, iend);
+        modify_text(start, end);
 
-        move_gap_both(iend, iend);
+        move_gap_both(end, end);
     }
 
     // Insert the decompressed data at the end of the compressed data.
-    let charpos = iend;
-    let bytepos = unsafe { buf_charpos_to_bytepos(current_buffer.as_mut(), iend as isize) };
+    let charpos = end;
+    let bytepos = unsafe { buf_charpos_to_bytepos(current_buffer.as_mut(), end) };
     let old_pt = current_buffer.pt;
     current_buffer.set_pt_both(charpos, bytepos);
 
     let compressed_buffer = unsafe {
-        slice::from_raw_parts(
-            current_buffer.byte_pos_addr(istart),
-            (iend - istart) as usize,
-        )
+        slice::from_raw_parts(current_buffer.byte_pos_addr(start), (end - start) as usize)
     };
 
     // The decompressor
@@ -103,12 +97,12 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
                 // Delete the compressed data.
                 unsafe {
                     del_range_2(
-                        istart, istart, // byte, char offsets the same
-                        iend, iend, false,
+                        start, start, // byte, char offsets the same
+                        end, end, false,
                     );
-                    signal_after_change(istart, iend - istart, decompressed_bytes);
+                    signal_after_change(start, end - start, decompressed_bytes);
 
-                    update_compositions(istart, istart, CHECK_HEAD as i32);
+                    update_compositions(start, start, CHECK_HEAD as i32);
                 };
                 return true;
             }
@@ -129,9 +123,9 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
                 // Delete any uncompressed data already inserted on error, but
                 // without calling the change hooks.
 
-                let data_orig = istart;
-                let data_start = iend;
-                let data_end = iend + decompressed_bytes;
+                let data_orig = start;
+                let data_start = end;
+                let data_end = end + decompressed_bytes;
 
                 unsafe {
                     del_range_2(


### PR DESCRIPTION
The C function takes two pointers. In Rust, we can return a tuple instead. Less unsafe is good.