### PR TITLE
Added intspec for eval_region

### DIFF
--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -270,7 +270,7 @@ pub fn get_file_char() -> EmacsInt {
 /// which is the input stream for reading characters.
 ///
 /// This function does not move point.
-#[lisp_fn(min = "2")]
+#[lisp_fn(min = "2", intspec = "r")]
 pub fn eval_region(
     start: LispObject,
     end: LispObject,


### PR DESCRIPTION
Using the same value for intspec as the original [C-code DEFUN sixth argument](https://github.com/emacs-mirror/emacs/blob/master/src/lread.c#L2161).

Closes #1346