### PR TITLE
Refactor charpos and bytepos functions.

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -10,7 +10,6 @@ use crate::{
     base64_crate,
     buffers::validate_region_rust,
     lisp::LispObject,
-    marker::buf_charpos_to_bytepos,
     multibyte::{multibyte_char_at, raw_byte_from_codepoint, LispStringRef, MAX_5_BYTE_CHAR},
     remacs_sys::EmacsInt,
     remacs_sys::{
@@ -271,11 +270,11 @@ pub fn base64_decode_string(string: LispStringRef) -> LispObject {
 #[lisp_fn(min = "2", intspec = "r")]
 pub fn base64_encode_region(beg: LispObject, end: LispObject, no_line_break: bool) -> EmacsInt {
     let (beg, end) = validate_region_rust(beg, end);
-    let mut current_buffer = ThreadState::current_buffer_unchecked();
+    let current_buffer = ThreadState::current_buffer_unchecked();
     let old_pos = current_buffer.pt;
 
-    let begpos = buf_charpos_to_bytepos(current_buffer, beg);
-    let endpos = buf_charpos_to_bytepos(current_buffer, end);
+    let begpos = current_buffer.charpos_to_bytepos(beg);
+    let endpos = current_buffer.charpos_to_bytepos(end);
 
     unsafe { move_gap_both(beg, begpos) };
 
@@ -316,8 +315,8 @@ pub fn base64_decode_region(beg: LispObject, end: LispObject) -> EmacsInt {
     let mut current_buffer = ThreadState::current_buffer_unchecked();
     let mut old_pos = current_buffer.pt;
 
-    let begpos = buf_charpos_to_bytepos(current_buffer, beg);
-    let endpos = buf_charpos_to_bytepos(current_buffer, end);
+    let begpos = current_buffer.charpos_to_bytepos(beg);
+    let endpos = current_buffer.charpos_to_bytepos(end);
 
     let multibyte = current_buffer.multibyte_characters_enabled();
     let length = (endpos - begpos) as usize;

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -274,8 +274,8 @@ pub fn base64_encode_region(beg: LispObject, end: LispObject, no_line_break: boo
     let mut current_buffer = ThreadState::current_buffer_unchecked();
     let old_pos = current_buffer.pt;
 
-    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), beg);
-    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), end);
+    let begpos = buf_charpos_to_bytepos(current_buffer, beg);
+    let endpos = buf_charpos_to_bytepos(current_buffer, end);
 
     unsafe { move_gap_both(beg, begpos) };
 
@@ -316,8 +316,8 @@ pub fn base64_decode_region(beg: LispObject, end: LispObject) -> EmacsInt {
     let mut current_buffer = ThreadState::current_buffer_unchecked();
     let mut old_pos = current_buffer.pt;
 
-    let begpos = buf_charpos_to_bytepos(current_buffer.as_mut(), beg);
-    let endpos = buf_charpos_to_bytepos(current_buffer.as_mut(), end);
+    let begpos = buf_charpos_to_bytepos(current_buffer, beg);
+    let endpos = buf_charpos_to_bytepos(current_buffer, end);
 
     let multibyte = current_buffer.multibyte_characters_enabled();
     let length = (endpos - begpos) as usize;

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -21,8 +21,11 @@ use crate::{
     lisp::{ExternalPtr, LispMiscRef, LispObject, LispStructuralEqual, LiveBufferIter},
     lists::{car, cdr, list, member, rassq, setcar},
     lists::{CarIter, LispConsCircularChecks, LispConsEndChecks},
-    marker::{build_marker, marker_buffer, marker_position_lisp, set_marker_both, LispMarkerRef},
-    multibyte::{multibyte_length_by_head, string_char},
+    marker::{
+        build_marker, build_marker_rust, marker_buffer, marker_position_lisp, set_marker_both,
+        LispMarkerRef, MARKER_DEBUG,
+    },
+    multibyte::{multibyte_chars_in_text, multibyte_length_by_head, string_char},
     multibyte::{LispStringRef, LispSymbolOrString},
     numbers::MOST_POSITIVE_FIXNUM,
     obarray::intern,
@@ -364,6 +367,246 @@ impl LispBufferRef {
 
     pub fn z(self) -> ptrdiff_t {
         unsafe { (*self.text).z }
+    }
+
+    pub fn bytepos_to_charpos(mut self, bytepos: isize) -> isize {
+        assert!(self.beg_byte() <= bytepos && bytepos <= self.z_byte());
+
+        let mut best_above = self.z();
+        let mut best_above_byte = self.z_byte();
+
+        // If this buffer has as many characters as bytes,
+        // each character must be one byte.
+        // This takes care of the case where enable-multibyte-characters is nil.
+        if best_above == best_above_byte {
+            return bytepos;
+        }
+
+        let mut best_below = self.beg();
+        let mut best_below_byte = self.beg_byte();
+
+        macro_rules! consider_known {
+            ($bpos:expr, $cpos:expr) => {
+                let mut changed = false;
+                if $bpos == bytepos {
+                    if MARKER_DEBUG {
+                        byte_char_debug_check(self, $cpos, bytepos);
+                    }
+                    return $cpos;
+                } else if $bpos > bytepos {
+                    if $bpos < best_above_byte {
+                        best_above = $cpos;
+                        best_above_byte = $bpos;
+                        changed = true;
+                    }
+                } else if $bpos > best_below_byte {
+                    best_below = $cpos;
+                    best_below_byte = $bpos;
+                    changed = true;
+                }
+                if changed {
+                    if best_above - best_below == best_above_byte - best_below_byte {
+                        return best_below + (bytepos - best_below_byte);
+                    }
+                }
+            };
+        }
+
+        consider_known!(self.pt_byte, self.pt);
+        consider_known!(self.gpt_byte(), self.gpt());
+        consider_known!(self.begv_byte, self.begv);
+        consider_known!(self.zv_byte, self.zv);
+
+        if self.is_cached && self.modifications() == self.cached_modiff {
+            consider_known!(self.cached_bytepos, self.cached_charpos);
+        }
+
+        for m in self.markers().iter() {
+            consider_known!(m.bytepos_or_error(), m.charpos_or_error());
+            // If we are down to a range of 50 chars,
+            // don't bother checking any other markers;
+            // scan the intervening chars directly now.
+            if best_above - best_below < 50 {
+                break;
+            }
+        }
+
+        // We get here if we did not exactly hit one of the known places.
+        // We have one known above and one known below.
+        // Scan, counting characters, from whichever one is closer.
+
+        if bytepos - best_below_byte < best_above_byte - bytepos {
+            let record = bytepos - best_below_byte > 5000;
+
+            while best_below_byte < bytepos {
+                best_below += 1;
+                best_below_byte = self.inc_pos(best_below_byte);
+            }
+
+            // If this position is quite far from the nearest known position,
+            // cache the correspondence by creating a marker here.
+            // It will last until the next GC.
+            // But don't do it if BUF_MARKERS is nil;
+            // that is a signal from Fset_buffer_multibyte.
+            if record && self.markers().is_some() {
+                build_marker_rust(self, best_below, best_below_byte);
+            }
+            if MARKER_DEBUG {
+                byte_char_debug_check(self, best_below, best_below_byte);
+            }
+
+            self.is_cached = true;
+            self.cached_modiff = self.modifications();
+
+            self.cached_charpos = best_below;
+            self.cached_bytepos = best_below_byte;
+
+            best_below
+        } else {
+            let record = best_above_byte - bytepos > 5000;
+
+            while best_above_byte > bytepos {
+                best_above -= 1;
+                best_above_byte = self.dec_pos(best_above_byte);
+            }
+
+            // If this position is quite far from the nearest known position,
+            // cache the correspondence by creating a marker here.
+            // It will last until the next GC.
+            // But don't do it if BUF_MARKERS is nil;
+            // that is a signal from Fset_buffer_multibyte.
+            if record && self.markers().is_some() {
+                build_marker_rust(self, best_below, best_below_byte);
+            }
+            if MARKER_DEBUG {
+                byte_char_debug_check(self, best_below, best_below_byte);
+            }
+
+            self.is_cached = true;
+            self.cached_modiff = self.modifications();
+
+            self.cached_charpos = best_above;
+            self.cached_bytepos = best_above_byte;
+
+            best_above
+        }
+    }
+
+    pub fn charpos_to_bytepos(mut self, charpos: isize) -> isize {
+        assert!(self.beg() <= charpos && charpos <= self.z());
+
+        let mut best_above = self.z();
+        let mut best_above_byte = self.z_byte();
+
+        // If this buffer has as many characters as bytes,
+        // each character must be one byte.
+        // This takes care of the case where enable-multibyte-characters is nil.
+        if best_above == best_above_byte {
+            return charpos;
+        }
+
+        let mut best_below = self.beg();
+        let mut best_below_byte = self.beg_byte();
+
+        // We find in best_above and best_above_byte
+        // the closest known point above CHARPOS,
+        // and in best_below and best_below_byte
+        // the closest known point below CHARPOS,
+        //
+        // If at any point we can tell that the space between those
+        // two best approximations is all single-byte,
+        // we interpolate the result immediately.
+
+        macro_rules! consider_known {
+            ($cpos:expr, $bpos:expr) => {
+                let mut changed = false;
+                if $cpos == charpos {
+                    if MARKER_DEBUG {
+                        byte_char_debug_check(self, charpos, $bpos);
+                    }
+                    return $bpos;
+                } else if $cpos > charpos {
+                    if $cpos < best_above {
+                        best_above = $cpos;
+                        best_above_byte = $bpos;
+                        changed = true;
+                    }
+                } else if $cpos > best_below {
+                    best_below = $cpos;
+                    best_below_byte = $bpos;
+                    changed = true;
+                }
+                if changed {
+                    if best_above - best_below == best_above_byte - best_below_byte {
+                        return best_below_byte + (charpos - best_below);
+                    }
+                }
+            };
+        }
+
+        consider_known!(self.pt, self.pt_byte);
+        consider_known!(self.gpt(), self.gpt_byte());
+        consider_known!(self.begv, self.begv_byte);
+        consider_known!(self.zv, self.zv_byte);
+
+        if self.is_cached && self.modifications() == self.cached_modiff {
+            consider_known!(self.cached_charpos, self.cached_bytepos);
+        }
+
+        for m in self.markers().iter() {
+            consider_known!(m.charpos_or_error(), m.bytepos_or_error());
+            // If we are down to a range of 50 chars,
+            // don't bother checking any other markers;
+            // scan the intervening chars directly now.
+            if best_above - best_below < 50 {
+                break;
+            }
+        }
+
+        if charpos - best_below < best_above - charpos {
+            let record = charpos - best_below > 5000;
+
+            while best_below != charpos {
+                best_below += 1;
+                best_below_byte = self.inc_pos(best_below_byte);
+            }
+            if record {
+                build_marker_rust(self, best_below, best_below_byte);
+            }
+            if MARKER_DEBUG {
+                byte_char_debug_check(self, best_below, best_below_byte);
+            }
+
+            self.is_cached = true;
+            self.cached_modiff = self.modifications();
+
+            self.cached_charpos = best_below;
+            self.cached_bytepos = best_below_byte;
+
+            best_below_byte
+        } else {
+            let record = best_above - charpos > 5000;
+
+            while best_above != charpos {
+                best_above -= 1;
+                best_above_byte = self.dec_pos(best_above_byte);
+            }
+
+            if record {
+                build_marker_rust(self, best_above, best_above_byte);
+            }
+            if MARKER_DEBUG {
+                byte_char_debug_check(self, best_below, best_below_byte);
+            }
+
+            self.is_cached = true;
+            self.cached_modiff = self.modifications();
+
+            self.cached_charpos = best_above;
+            self.cached_bytepos = best_above_byte;
+
+            best_above_byte
+        }
     }
 
     pub fn local_vars_iter(self) -> CarIter {
@@ -1299,6 +1542,27 @@ pub fn rename_buffer(newname: LispStringRef, unique: LispObject) -> LispStringRe
 
     // Refetch since that last call may have done GC.
     ThreadState::current_buffer_unchecked().name_.into()
+}
+
+// Debugging
+
+pub fn byte_char_debug_check(b: LispBufferRef, charpos: isize, bytepos: isize) {
+    if !b.multibyte_characters_enabled() {
+        return;
+    }
+
+    let nchars = unsafe {
+        if bytepos > b.gpt_byte() {
+            multibyte_chars_in_text(b.beg_addr(), b.gpt_byte() - b.beg_byte())
+                + multibyte_chars_in_text(b.gap_end_addr(), bytepos - b.gpt_byte())
+        } else {
+            multibyte_chars_in_text(b.beg_addr(), bytepos - b.beg_byte())
+        }
+    };
+
+    if charpos - 1 != nchars {
+        panic!("byte_char_debug_check failed.")
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/buffers_exports.rs"));

--- a/rust_src/src/decompress.rs
+++ b/rust_src/src/decompress.rs
@@ -9,9 +9,10 @@ use remacs_macros::lisp_fn;
 use crate::{
     buffers::validate_region_rust,
     lisp::LispObject,
+    marker::buf_charpos_to_bytepos,
     remacs_sys::{
-        buf_charpos_to_bytepos, del_range_2, insert_from_gap, make_gap, maybe_quit, modify_text,
-        move_gap_both, signal_after_change, update_compositions, CHECK_HEAD,
+        del_range_2, insert_from_gap, make_gap, maybe_quit, modify_text, move_gap_both,
+        signal_after_change, update_compositions, CHECK_HEAD,
     },
     threads::ThreadState,
 };
@@ -63,7 +64,7 @@ pub fn zlib_decompress_region(start: LispObject, end: LispObject) -> bool {
 
     // Insert the decompressed data at the end of the compressed data.
     let charpos = end;
-    let bytepos = unsafe { buf_charpos_to_bytepos(current_buffer.as_mut(), end) };
+    let bytepos = buf_charpos_to_bytepos(current_buffer, end);
     let old_pt = current_buffer.pt;
     current_buffer.set_pt_both(charpos, bytepos);
 
@@ -142,7 +143,7 @@ pub fn zlib_decompress_region(start: LispObject, end: LispObject) -> bool {
                 // compressed data is bigger than the uncompressed, at
                 // point-max.
                 let charpos = min(old_pt, current_buffer.zv);
-                let bytepos = unsafe { buf_charpos_to_bytepos(current_buffer.as_mut(), charpos) };
+                let bytepos = buf_charpos_to_bytepos(current_buffer, charpos);
                 current_buffer.set_pt_both(charpos, bytepos);
 
                 return false;

--- a/rust_src/src/decompress.rs
+++ b/rust_src/src/decompress.rs
@@ -9,7 +9,6 @@ use remacs_macros::lisp_fn;
 use crate::{
     buffers::validate_region_rust,
     lisp::LispObject,
-    marker::buf_charpos_to_bytepos,
     remacs_sys::{
         del_range_2, insert_from_gap, make_gap, maybe_quit, modify_text, move_gap_both,
         signal_after_change, update_compositions, CHECK_HEAD,
@@ -64,7 +63,7 @@ pub fn zlib_decompress_region(start: LispObject, end: LispObject) -> bool {
 
     // Insert the decompressed data at the end of the compressed data.
     let charpos = end;
-    let bytepos = buf_charpos_to_bytepos(current_buffer, end);
+    let bytepos = current_buffer.charpos_to_bytepos(end);
     let old_pt = current_buffer.pt;
     current_buffer.set_pt_both(charpos, bytepos);
 
@@ -143,7 +142,7 @@ pub fn zlib_decompress_region(start: LispObject, end: LispObject) -> bool {
                 // compressed data is bigger than the uncompressed, at
                 // point-max.
                 let charpos = min(old_pt, current_buffer.zv);
-                let bytepos = buf_charpos_to_bytepos(current_buffer, charpos);
+                let bytepos = current_buffer.charpos_to_bytepos(charpos);
                 current_buffer.set_pt_both(charpos, bytepos);
 
                 return false;

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -738,7 +738,7 @@ pub fn constrain_to_field(
 /// If BYTEPOS is out of range, the value is nil.
 #[lisp_fn]
 pub fn byte_to_position(bytepos: EmacsInt) -> Option<EmacsInt> {
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
+    let cur_buf = ThreadState::current_buffer_unchecked();
     let mut pos_byte = bytepos as isize;
     if pos_byte < cur_buf.beg_byte() || pos_byte > cur_buf.z_byte() {
         return None;

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -192,7 +192,7 @@ pub fn goto_char(position: LispObject) -> LispObject {
     } else if let Some(num) = position.as_fixnum() {
         let mut cur_buf = ThreadState::current_buffer_unchecked();
         let pos = clip_to_bounds(cur_buf.begv, num, cur_buf.zv);
-        let bytepos = buf_charpos_to_bytepos(cur_buf.as_mut(), pos);
+        let bytepos = buf_charpos_to_bytepos(cur_buf, pos);
         unsafe { set_point_both(pos, bytepos) };
     } else {
         wrong_type!(Qinteger_or_marker_p, position)
@@ -208,7 +208,7 @@ pub fn position_bytes(position: LispNumber) -> Option<EmacsInt> {
     let mut cur_buf = ThreadState::current_buffer_unchecked();
 
     if pos >= cur_buf.begv && pos <= cur_buf.zv {
-        let bytepos = buf_charpos_to_bytepos(cur_buf.as_mut(), pos);
+        let bytepos = buf_charpos_to_bytepos(cur_buf, pos);
         Some(bytepos as EmacsInt)
     } else {
         None
@@ -366,7 +366,7 @@ pub fn char_before(pos: LispObject) -> Option<EmacsInt> {
         if p <= buffer_ref.begv || p > buffer_ref.zv {
             return None;
         }
-        pos_byte = buf_charpos_to_bytepos(buffer_ref.as_mut(), p);
+        pos_byte = buf_charpos_to_bytepos(buffer_ref, p);
     }
 
     let pos_before = if buffer_ref.multibyte_characters_enabled() {
@@ -400,7 +400,7 @@ pub fn char_after(mut pos: LispObject) -> Option<EmacsInt> {
         if p < buffer_ref.begv || p >= buffer_ref.zv {
             None
         } else {
-            let pos_byte = buf_charpos_to_bytepos(buffer_ref.as_mut(), p);
+            let pos_byte = buf_charpos_to_bytepos(buffer_ref, p);
             Some(EmacsInt::from(buffer_ref.fetch_char(pos_byte)))
         }
     }

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -17,10 +17,7 @@ use crate::{
     eval::{progn, record_unwind_protect, unbind_to},
     indent::invalidate_current_column,
     lisp::LispObject,
-    marker::{
-        buf_bytepos_to_charpos, buf_charpos_to_bytepos, marker_position_lisp, point_marker,
-        set_point_from_marker,
-    },
+    marker::{marker_position_lisp, point_marker, set_point_from_marker},
     multibyte::{
         is_single_byte_char, multibyte_char_at, raw_byte_codepoint, raw_byte_from_codepoint,
         unibyte_to_char, write_codepoint, MAX_MULTIBYTE_LENGTH,
@@ -190,9 +187,9 @@ pub fn goto_char(position: LispObject) -> LispObject {
     if position.is_marker() {
         set_point_from_marker(position);
     } else if let Some(num) = position.as_fixnum() {
-        let mut cur_buf = ThreadState::current_buffer_unchecked();
+        let cur_buf = ThreadState::current_buffer_unchecked();
         let pos = clip_to_bounds(cur_buf.begv, num, cur_buf.zv);
-        let bytepos = buf_charpos_to_bytepos(cur_buf, pos);
+        let bytepos = cur_buf.charpos_to_bytepos(pos);
         unsafe { set_point_both(pos, bytepos) };
     } else {
         wrong_type!(Qinteger_or_marker_p, position)
@@ -205,10 +202,10 @@ pub fn goto_char(position: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn position_bytes(position: LispNumber) -> Option<EmacsInt> {
     let pos = position.to_fixnum() as ptrdiff_t;
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
+    let cur_buf = ThreadState::current_buffer_unchecked();
 
     if pos >= cur_buf.begv && pos <= cur_buf.zv {
-        let bytepos = buf_charpos_to_bytepos(cur_buf, pos);
+        let bytepos = cur_buf.charpos_to_bytepos(pos);
         Some(bytepos as EmacsInt)
     } else {
         None
@@ -345,7 +342,7 @@ pub fn preceding_char() -> EmacsInt {
 /// If POS is out of range, the value is nil.
 #[lisp_fn(min = "0")]
 pub fn char_before(pos: LispObject) -> Option<EmacsInt> {
-    let mut buffer_ref = ThreadState::current_buffer_unchecked();
+    let buffer_ref = ThreadState::current_buffer_unchecked();
     let pos_byte: isize;
 
     if pos.is_nil() {
@@ -366,7 +363,7 @@ pub fn char_before(pos: LispObject) -> Option<EmacsInt> {
         if p <= buffer_ref.begv || p > buffer_ref.zv {
             return None;
         }
-        pos_byte = buf_charpos_to_bytepos(buffer_ref, p);
+        pos_byte = buffer_ref.charpos_to_bytepos(p);
     }
 
     let pos_before = if buffer_ref.multibyte_characters_enabled() {
@@ -382,7 +379,7 @@ pub fn char_before(pos: LispObject) -> Option<EmacsInt> {
 /// If POS is out of range, the value is nil.
 #[lisp_fn(min = "0")]
 pub fn char_after(mut pos: LispObject) -> Option<EmacsInt> {
-    let mut buffer_ref = ThreadState::current_buffer_unchecked();
+    let buffer_ref = ThreadState::current_buffer_unchecked();
     if pos.is_nil() {
         pos = point().into();
     }
@@ -400,7 +397,7 @@ pub fn char_after(mut pos: LispObject) -> Option<EmacsInt> {
         if p < buffer_ref.begv || p >= buffer_ref.zv {
             None
         } else {
-            let pos_byte = buf_charpos_to_bytepos(buffer_ref, p);
+            let pos_byte = buffer_ref.charpos_to_bytepos(p);
             Some(EmacsInt::from(buffer_ref.fetch_char(pos_byte)))
         }
     }
@@ -756,7 +753,7 @@ pub fn byte_to_position(bytepos: EmacsInt) -> Option<EmacsInt> {
         }
     }
 
-    Some(unsafe { buf_bytepos_to_charpos(cur_buf.as_mut(), pos_byte) } as EmacsInt)
+    Some(cur_buf.bytepos_to_charpos(pos_byte) as EmacsInt)
 }
 
 /// Return t if two characters match, optionally ignoring case.
@@ -1116,7 +1113,7 @@ pub extern "C" fn save_excursion_save() -> LispObject {
 
     unsafe {
         make_save_obj_obj_obj_obj(
-            point_marker(),
+            point_marker().into(),
             Qnil,
             // Selected window if current buffer is shown in it, nil otherwise.
             if window.contents.eq(current_buffer()) {

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -10,7 +10,6 @@ use crate::{
     buffers::{current_buffer, LispBufferRef},
     hashtable::LispHashTableRef,
     lisp::{ExternalPtr, LispMiscRef, LispObject, LispStructuralEqual},
-    multibyte::multibyte_chars_in_text,
     remacs_sys::{allocate_misc, set_point_both, Fmake_marker},
     remacs_sys::{equal_kind, EmacsInt, Lisp_Buffer, Lisp_Marker, Lisp_Misc_Type, Lisp_Type},
     remacs_sys::{Qinteger_or_marker_p, Qmarkerp},
@@ -20,11 +19,7 @@ use crate::{
 
 pub type LispMarkerRef = ExternalPtr<Lisp_Marker>;
 
-#[cfg(MARKER_DEBUG)]
-const MARKER_DEBUG: bool = true;
-
-#[cfg(not(MARKER_DEBUG))]
-const MARKER_DEBUG: bool = false;
+pub const MARKER_DEBUG: bool = cfg!(MARKER_DEBUG);
 
 impl LispMarkerRef {
     pub fn charpos(self) -> Option<isize> {
@@ -193,70 +188,81 @@ pub extern "C" fn build_marker(
     charpos: ptrdiff_t,
     bytepos: ptrdiff_t,
 ) -> LispObject {
-    debug_assert!(unsafe { (*buf).name_.is_not_nil() });
+    let buffer = LispBufferRef::from_ptr(buf as *mut c_void)
+        .unwrap_or_else(|| panic!("Invalid buffer reference."));
+    build_marker_rust(buffer, charpos as isize, bytepos as isize).into()
+}
+
+pub fn build_marker_rust(
+    mut buffer: LispBufferRef,
+    charpos: isize,
+    bytepos: isize,
+) -> LispMarkerRef {
+    debug_assert!(buffer.name_.is_not_nil());
     debug_assert!(charpos <= bytepos);
 
-    let obj = unsafe { allocate_misc(Lisp_Misc_Type::Lisp_Misc_Marker) };
-    let mut m: LispMarkerRef = obj.into();
+    let mut marker: LispMarkerRef =
+        unsafe { allocate_misc(Lisp_Misc_Type::Lisp_Misc_Marker) }.into();
 
-    m.set_buffer(buf);
-    m.set_charpos(charpos);
-    m.set_bytepos(bytepos);
-    m.set_insertion_type(false);
-    m.set_need_adjustment(false);
-
-    let mut buffer_ref = LispBufferRef::from_ptr(buf as *mut c_void)
-        .unwrap_or_else(|| panic!("Invalid buffer reference."));
+    marker.set_buffer(buffer.as_mut());
+    marker.set_charpos(charpos);
+    marker.set_bytepos(bytepos);
+    marker.set_insertion_type(false);
+    marker.set_need_adjustment(false);
 
     unsafe {
-        m.set_next((*buffer_ref.text).markers);
-        (*buffer_ref.text).markers = m.as_mut();
+        marker.set_next((*buffer.text).markers);
+        (*buffer.text).markers = marker.as_mut();
     }
 
-    obj
+    marker
 }
 
 /// Return value of point, as a marker object.
 #[lisp_fn]
-pub fn point_marker() -> LispObject {
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
-    build_marker(cur_buf.as_mut(), cur_buf.pt, cur_buf.pt_byte)
+pub fn point_marker() -> LispMarkerRef {
+    let cur_buf = ThreadState::current_buffer_unchecked();
+    build_marker_rust(cur_buf, cur_buf.pt, cur_buf.pt_byte)
 }
 
 /// Return a marker to the minimum permissible value of point in this buffer.
 /// This is the beginning, unless narrowing (a buffer restriction) is in effect.
 #[lisp_fn]
-pub fn point_min_marker() -> LispObject {
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
-    build_marker(cur_buf.as_mut(), cur_buf.begv, cur_buf.begv_byte)
+pub fn point_min_marker() -> LispMarkerRef {
+    let cur_buf = ThreadState::current_buffer_unchecked();
+    build_marker_rust(cur_buf, cur_buf.begv, cur_buf.begv_byte)
 }
 
 /// Return a marker to the maximum permissible value of point in this buffer.
 /// This is (1+ (buffer-size)), unless narrowing (a buffer restriction)
 /// is in effect, in which case it is less.
 #[lisp_fn]
-pub fn point_max_marker() -> LispObject {
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
-    build_marker(cur_buf.as_mut(), cur_buf.zv, cur_buf.zv_byte)
+pub fn point_max_marker() -> LispMarkerRef {
+    let cur_buf = ThreadState::current_buffer_unchecked();
+    build_marker_rust(cur_buf, cur_buf.zv, cur_buf.zv_byte)
 }
 
 /// Set PT from MARKER's clipped position.
 #[no_mangle]
 pub extern "C" fn set_point_from_marker(marker: LispObject) {
     let marker: LispMarkerRef = marker.into();
-    let mut cur_buf = ThreadState::current_buffer_unchecked();
+    let cur_buf = ThreadState::current_buffer_unchecked();
     let charpos = clip_to_bounds(
         cur_buf.begv,
         marker.charpos_or_error() as EmacsInt,
         cur_buf.zv,
     );
-    let mut bytepos = marker.bytepos_or_error();
+
     // Don't trust the byte position if the marker belongs to a
     // different buffer.
-    if marker.buffer().map_or(false, |b| b != cur_buf) {
-        bytepos = buf_charpos_to_bytepos(cur_buf, charpos);
+    let bytepos = if marker.buffer().map_or(false, |b| b != cur_buf) {
+        cur_buf.charpos_to_bytepos(charpos)
     } else {
-        bytepos = clip_to_bounds(cur_buf.begv_byte, bytepos as EmacsInt, cur_buf.zv_byte);
+        clip_to_bounds(
+            cur_buf.begv_byte,
+            marker.bytepos_or_error() as EmacsInt,
+            cur_buf.zv_byte,
+        )
     };
     unsafe { set_point_both(charpos, bytepos) };
 }
@@ -552,7 +558,7 @@ fn set_marker_internal_else(
             .as_marker()
             .map_or(false, |m| m.buffer() == Some(buf))
     {
-        bytepos = buf_charpos_to_bytepos(buf, charpos);
+        bytepos = buf.charpos_to_bytepos(charpos);
     } else {
         let beg = buf.buffer_beg_byte(restricted);
         let end = buf.buffer_end_byte(restricted);
@@ -605,251 +611,14 @@ impl LispBufferRef {
 /// Return the byte position corresponding to CHARPOS in B.
 #[no_mangle]
 pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) -> isize {
-    let mut buffer_ref = LispBufferRef::from_ptr(b as *mut c_void).unwrap();
-    buf_charpos_to_bytepos_rust(buffer_ref, charpos)
-}
-
-pub fn buf_charpos_to_bytepos_rust(buffer: LispBufferRef, charpos: isize) -> isize {
-    assert!(buffer.beg() <= charpos && charpos <= buffer.z());
-
-    let mut best_above = buffer.z();
-    let mut best_above_byte = buffer.z_byte();
-
-    // If this buffer has as many characters as bytes,
-    // each character must be one byte.
-    // This takes care of the case where enable-multibyte-characters is nil.
-    if best_above == best_above_byte {
-        return charpos;
-    }
-
-    let mut best_below = buffer.beg();
-    let mut best_below_byte = buffer.beg_byte();
-
-    // We find in best_above and best_above_byte
-    // the closest known point above CHARPOS,
-    // and in best_below and best_below_byte
-    // the closest known point below CHARPOS,
-    //
-    // If at any point we can tell that the space between those
-    // two best approximations is all single-byte,
-    // we interpolate the result immediately.
-
-    macro_rules! consider_known {
-        ($cpos:expr, $bpos:expr) => {
-            let mut changed = false;
-            if $cpos == charpos {
-                if MARKER_DEBUG {
-                    byte_char_debug_check(buffer, charpos, $bpos);
-                }
-                return $bpos;
-            } else if $cpos > charpos {
-                if $cpos < best_above {
-                    best_above = $cpos;
-                    best_above_byte = $bpos;
-                    changed = true;
-                }
-            } else if $cpos > best_below {
-                best_below = $cpos;
-                best_below_byte = $bpos;
-                changed = true;
-            }
-            if changed {
-                if best_above - best_below == best_above_byte - best_below_byte {
-                    return best_below_byte + (charpos - best_below);
-                }
-            }
-        };
-    }
-
-    consider_known!(buffer.pt, buffer.pt_byte);
-    consider_known!(buffer.gpt(), buffer.gpt_byte());
-    consider_known!(buffer.begv, buffer.begv_byte);
-    consider_known!(buffer.zv, buffer.zv_byte);
-
-    if buffer.is_cached && buffer.modifications() == buffer.cached_modiff {
-        consider_known!(buffer.cached_charpos, buffer.cached_bytepos);
-    }
-
-    for m in buffer.markers().iter() {
-        consider_known!(m.charpos_or_error(), m.bytepos_or_error());
-        // If we are down to a range of 50 chars,
-        // don't bother checking any other markers;
-        // scan the intervening chars directly now.
-        if best_above - best_below < 50 {
-            break;
-        }
-    }
-
-    if charpos - best_below < best_above - charpos {
-        let record = charpos - best_below > 5000;
-
-        while best_below != charpos {
-            best_below += 1;
-            best_below_byte = buffer.inc_pos(best_below_byte);
-        }
-        if record {
-            build_marker(b, best_below, best_below_byte);
-        }
-        if MARKER_DEBUG {
-            byte_char_debug_check(buffer, best_below, best_below_byte);
-        }
-
-        buffer.is_cached = true;
-        buffer.cached_modiff = buffer.modifications();
-
-        buffer.cached_charpos = best_below;
-        buffer.cached_bytepos = best_below_byte;
-
-        best_below_byte
-    } else {
-        let record = best_above - charpos > 5000;
-
-        while best_above != charpos {
-            best_above -= 1;
-            best_above_byte = buffer.dec_pos(best_above_byte);
-        }
-
-        if record {
-            build_marker(b, best_above, best_above_byte);
-        }
-        if MARKER_DEBUG {
-            byte_char_debug_check(buffer, best_below, best_below_byte);
-        }
-
-        buffer.is_cached = true;
-        buffer.cached_modiff = buffer.modifications();
-
-        buffer.cached_charpos = best_above;
-        buffer.cached_bytepos = best_above_byte;
-
-        best_above_byte
-    }
+    let buffer = LispBufferRef::from_ptr(b as *mut c_void).unwrap();
+    buffer.charpos_to_bytepos(charpos)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) -> isize {
-    let mut buffer_ref = LispBufferRef::from_ptr(b as *mut c_void).unwrap();
-
-    assert!(buffer_ref.beg_byte() <= bytepos && bytepos <= buffer_ref.z_byte());
-
-    let mut best_above = buffer_ref.z();
-    let mut best_above_byte = buffer_ref.z_byte();
-
-    // If this buffer has as many characters as bytes,
-    // each character must be one byte.
-    // This takes care of the case where enable-multibyte-characters is nil.
-    if best_above == best_above_byte {
-        return bytepos;
-    }
-
-    let mut best_below = buffer_ref.beg();
-    let mut best_below_byte = buffer_ref.beg_byte();
-
-    macro_rules! consider_known {
-        ($bpos:expr, $cpos:expr) => {
-            let mut changed = false;
-            if $bpos == bytepos {
-                if MARKER_DEBUG {
-                    byte_char_debug_check(buffer_ref, $cpos, bytepos);
-                }
-                return $cpos;
-            } else if $bpos > bytepos {
-                if $bpos < best_above_byte {
-                    best_above = $cpos;
-                    best_above_byte = $bpos;
-                    changed = true;
-                }
-            } else if $bpos > best_below_byte {
-                best_below = $cpos;
-                best_below_byte = $bpos;
-                changed = true;
-            }
-            if changed {
-                if best_above - best_below == best_above_byte - best_below_byte {
-                    return best_below + (bytepos - best_below_byte);
-                }
-            }
-        };
-    }
-
-    consider_known!(buffer_ref.pt_byte, buffer_ref.pt);
-    consider_known!(buffer_ref.gpt_byte(), buffer_ref.gpt());
-    consider_known!(buffer_ref.begv_byte, buffer_ref.begv);
-    consider_known!(buffer_ref.zv_byte, buffer_ref.zv);
-
-    if buffer_ref.is_cached && buffer_ref.modifications() == buffer_ref.cached_modiff {
-        consider_known!(buffer_ref.cached_bytepos, buffer_ref.cached_charpos);
-    }
-
-    for m in buffer_ref.markers().iter() {
-        consider_known!(m.bytepos_or_error(), m.charpos_or_error());
-        // If we are down to a range of 50 chars,
-        // don't bother checking any other markers;
-        // scan the intervening chars directly now.
-        if best_above - best_below < 50 {
-            break;
-        }
-    }
-
-    // We get here if we did not exactly hit one of the known places.
-    // We have one known above and one known below.
-    // Scan, counting characters, from whichever one is closer.
-
-    if bytepos - best_below_byte < best_above_byte - bytepos {
-        let record = bytepos - best_below_byte > 5000;
-
-        while best_below_byte < bytepos {
-            best_below += 1;
-            best_below_byte = buffer_ref.inc_pos(best_below_byte);
-        }
-
-        // If this position is quite far from the nearest known position,
-        // cache the correspondence by creating a marker here.
-        // It will last until the next GC.
-        // But don't do it if BUF_MARKERS is nil;
-        // that is a signal from Fset_buffer_multibyte.
-        if record && buffer_ref.markers().is_some() {
-            build_marker(b, best_below, best_below_byte);
-        }
-        if MARKER_DEBUG {
-            byte_char_debug_check(buffer_ref, best_below, best_below_byte);
-        }
-
-        buffer_ref.is_cached = true;
-        buffer_ref.cached_modiff = buffer_ref.modifications();
-
-        buffer_ref.cached_charpos = best_below;
-        buffer_ref.cached_bytepos = best_below_byte;
-
-        best_below
-    } else {
-        let record = best_above_byte - bytepos > 5000;
-
-        while best_above_byte > bytepos {
-            best_above -= 1;
-            best_above_byte = buffer_ref.dec_pos(best_above_byte);
-        }
-
-        // If this position is quite far from the nearest known position,
-        // cache the correspondence by creating a marker here.
-        // It will last until the next GC.
-        // But don't do it if BUF_MARKERS is nil;
-        // that is a signal from Fset_buffer_multibyte.
-        if record && buffer_ref.markers().is_some() {
-            build_marker(b, best_below, best_below_byte);
-        }
-        if MARKER_DEBUG {
-            byte_char_debug_check(buffer_ref, best_below, best_below_byte);
-        }
-
-        buffer_ref.is_cached = true;
-        buffer_ref.cached_modiff = buffer_ref.modifications();
-
-        buffer_ref.cached_charpos = best_above;
-        buffer_ref.cached_bytepos = best_above_byte;
-
-        best_above
-    }
+    let buffer = LispBufferRef::from_ptr(b as *mut c_void).unwrap();
+    buffer.bytepos_to_charpos(bytepos)
 }
 
 #[no_mangle]
@@ -857,51 +626,6 @@ pub extern "C" fn clear_charpos_cache(b: *mut Lisp_Buffer) {
     let mut buf_ref = LispBufferRef::from_ptr(b as *mut c_void)
         .unwrap_or_else(|| panic!("Invalid buffer reference."));
     buf_ref.is_cached = false;
-}
-
-// Debugging
-
-fn byte_char_debug_check(b: LispBufferRef, charpos: isize, bytepos: isize) {
-    if !b.multibyte_characters_enabled() {
-        return;
-    }
-
-    let nchars = unsafe {
-        if bytepos > b.gpt_byte() {
-            multibyte_chars_in_text(b.beg_addr(), b.gpt_byte() - b.beg_byte())
-                + multibyte_chars_in_text(b.gap_end_addr(), bytepos - b.gpt_byte())
-        } else {
-            multibyte_chars_in_text(b.beg_addr(), bytepos - b.beg_byte())
-        }
-    };
-
-    if charpos - 1 != nchars {
-        panic!("byte_char_debug_check failed.")
-    }
-}
-
-/// Count the markers in buffer BUF.
-#[cfg(MARKER_DEBUG)]
-fn count_markers(buf: LispBufferRef) -> u8 {
-    let mut total = 0;
-    for _m in buf.markers().iter() {
-        total += 1;
-    }
-    total
-}
-
-/// Recompute the bytepos corresponding to CHARPOS in the simplest, most reliable way.
-#[cfg(MARKER_DEBUG)]
-fn verify_bytepos(charpos: isize) -> isize {
-    let mut below: isize = 1;
-    let mut below_byte: isize = 1;
-    let cur_buf = ThreadState::current_buffer_unchecked();
-
-    while below != charpos {
-        below += 1;
-        below_byte = cur_buf.inc_pos(below_byte);
-    }
-    below_byte
 }
 
 include!(concat!(env!("OUT_DIR"), "/marker_exports.rs"));


### PR DESCRIPTION
Convert the core logic to methods on `LispBufferRef`.
Update exported functions to use the methods.

This removes a few more unsafes. No logic was touched.