### PR TITLE
Port make-char-table

### DIFF
--- a/rust_src/src/casetab.rs
+++ b/rust_src/src/casetab.rs
@@ -5,14 +5,14 @@ use remacs_macros::lisp_fn;
 use crate::{
     buffers::current_buffer,
     buffers::LispBufferRef,
-    chartable::LispCharTableRef,
+    chartable::{make_char_table, LispCharTableRef},
     lisp::LispObject,
     lists::put,
     objects::eq,
     remacs_sys::EmacsInt,
     remacs_sys::{
         map_char_table, set_char_table_extras, set_char_table_purpose, staticpro, Fcopy_sequence,
-        Fmake_char_table, Fset_char_table_range, CHAR_TABLE_SET,
+        Fset_char_table_range, CHAR_TABLE_SET,
     },
     remacs_sys::{Qcase_table, Qcase_table_p, Qchar_table_extra_slots, Qnil},
     threads::ThreadState,
@@ -56,20 +56,20 @@ fn set_case_table(table: LispObject, standard: bool) -> LispObject {
 
     unsafe {
         if up.is_nil() {
-            up = Fmake_char_table(Qcase_table, Qnil);
+            up = make_char_table(Qcase_table, Qnil);
             map_char_table(Some(set_identity), Qnil, table, up);
             map_char_table(Some(shuffle), Qnil, table, up);
             set_char_table_extras(table, 0, up);
         }
 
         if canon.is_nil() {
-            canon = Fmake_char_table(Qcase_table, Qnil);
+            canon = make_char_table(Qcase_table, Qnil);
             set_char_table_extras(table, 1, canon);
             map_char_table(Some(set_canon), Qnil, table, table);
         }
 
         if eqv.is_nil() {
-            eqv = Fmake_char_table(Qcase_table, Qnil);
+            eqv = make_char_table(Qcase_table, Qnil);
             map_char_table(Some(set_identity), Qnil, canon, eqv);
             map_char_table(Some(shuffle), Qnil, canon, eqv);
             set_char_table_extras(table, 2, eqv);
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn init_casetab_once() {
     def_lisp_sym!(Qcase_table, "case-table");
     put(Qcase_table.into(), Qchar_table_extra_slots, 3.into());
 
-    let down = Fmake_char_table(Qcase_table, Qnil);
+    let down = make_char_table(Qcase_table, Qnil);
     set_char_table_purpose(down, Qcase_table);
     Vascii_downcase_table = down;
 
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn init_casetab_once() {
 
     set_char_table_extras(down, 1, Fcopy_sequence(down));
 
-    let up = Fmake_char_table(Qcase_table, Qnil);
+    let up = make_char_table(Qcase_table, Qnil);
     set_char_table_extras(down, 0, up);
 
     for i in 0..128 {
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn init_casetab_once() {
         CHAR_TABLE_SET(up, i, c.into());
     }
 
-    let eqv = Fmake_char_table(Qcase_table, Qnil);
+    let eqv = make_char_table(Qcase_table, Qnil);
 
     for i in 0..128 {
         // Set up a table for the lower 7 bits of ASCII.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -9,6 +9,7 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     buffers::current_buffer,
+    chartable::make_char_table,
     data::{aref, fset, indirect_function, set},
     eval::{autoload_do_load, unbind_to},
     indent::indent_to,
@@ -23,10 +24,7 @@ use crate::{
         map_keymap_item, maybe_quit, specbind,
     },
     remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt},
-    remacs_sys::{
-        Fcopy_sequence, Fevent_convert_list, Fmake_char_table, Fpurecopy, Fset_char_table_range,
-        Fterpri,
-    },
+    remacs_sys::{Fcopy_sequence, Fevent_convert_list, Fpurecopy, Fset_char_table_range, Fterpri},
     remacs_sys::{
         Qautoload, Qkeymap, Qkeymapp, Qnil, Qstandard_output, Qt, Qvector_or_char_table_p,
     },
@@ -158,7 +156,7 @@ pub fn make_keymap(string: LispObject) -> (LispObject, (LispObject, LispObject))
         Qnil
     };
 
-    let char_table = unsafe { Fmake_char_table(Qkeymap, Qnil) };
+    let char_table = make_char_table(Qkeymap.into(), Qnil);
     (Qkeymap, (char_table, tail))
 }
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -164,6 +164,14 @@ impl LispVectorlikeRef {
         }
     }
 
+    pub fn set_pseudovector_type(mut self, code: pvec_type) {
+        unsafe {
+            self.header.size |= (PSEUDOVECTOR_FLAG
+                | ((code as usize) << More_Lisp_Bits::PSEUDOVECTOR_AREA_BITS))
+                as isize
+        }
+    }
+
     pub fn is_pseudovector(self, tp: pvec_type) -> bool {
         unsafe {
             self.header.size

--- a/src/chartab.c
+++ b/src/chartab.c
@@ -96,42 +96,6 @@ set_char_table_parent (Lisp_Object table, Lisp_Object val)
   XCHAR_TABLE (table)->parent = val;
 }
 
-DEFUN ("make-char-table", Fmake_char_table, Smake_char_table, 1, 2, 0,
-       doc: /* Return a newly created char-table, with purpose PURPOSE.
-Each element is initialized to INIT, which defaults to nil.
-
-PURPOSE should be a symbol.  If it has a `char-table-extra-slots'
-property, the property's value should be an integer between 0 and 10
-that specifies how many extra slots the char-table has.  Otherwise,
-the char-table has no extra slot.  */)
-  (register Lisp_Object purpose, Lisp_Object init)
-{
-  Lisp_Object vector;
-  Lisp_Object n;
-  int n_extras;
-  int size;
-
-  CHECK_SYMBOL (purpose);
-  n = Fget (purpose, Qchar_table_extra_slots);
-  if (NILP (n))
-    n_extras = 0;
-  else
-    {
-      CHECK_NATNUM (n);
-      if (XINT (n) > 10)
-	args_out_of_range (n, Qnil);
-      n_extras = XINT (n);
-    }
-
-  size = CHAR_TABLE_STANDARD_SLOTS + n_extras;
-  vector = Fmake_vector (make_number (size), init);
-  XSETPVECTYPE (XVECTOR (vector), PVEC_CHAR_TABLE);
-  set_char_table_parent (vector, Qnil);
-  set_char_table_purpose (vector, purpose);
-  XSETCHAR_TABLE (vector, XCHAR_TABLE (vector));
-  return vector;
-}
-
 static Lisp_Object
 make_sub_char_table (int depth, int min_char, Lisp_Object defalt)
 {
@@ -1320,7 +1284,6 @@ syms_of_chartab (void)
   /* Purpose of uniprop tables. */
   DEFSYM (Qchar_code_property_table, "char-code-property-table");
 
-  defsubr (&Smake_char_table);
   defsubr (&Schar_table_extra_slot);
   defsubr (&Sset_char_table_extra_slot);
   defsubr (&Schar_table_range);


### PR DESCRIPTION
I'm surprised I couldn't find an existing `set_pseudovector_type`. Did I miss it, or has there just not been a need for one?