### PR TITLE
Port lock-buffer and unlock-buffer

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -362,6 +362,11 @@ impl LispBufferRef {
         unsafe { (*self.text).chars_modiff }
     }
 
+    /// Check if buffer was modified since its file was last read or saved.
+    pub fn modified_since_save(self) -> bool {
+        self.modifications_since_save() < self.modifications()
+    }
+
     pub fn overlay_modifications(self) -> EmacsInt {
         unsafe { (*self.text).overlay_modiff }
     }
@@ -1127,7 +1132,7 @@ pub fn buffer_file_name(buffer: LispBufferOrCurrent) -> LispObject {
 #[lisp_fn(min = "0")]
 pub fn buffer_modified_p(buffer: LispBufferOrCurrent) -> bool {
     let buf: LispBufferRef = buffer.into();
-    buf.modifications_since_save() < buf.modifications()
+    buf.modified_since_save()
 }
 
 /// Return the name of BUFFER, as a string.

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -4,8 +4,8 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     lisp::LispObject,
-    remacs_sys::{lock_file, unlock_file},
     remacs_sys::Qstringp,
+    remacs_sys::{lock_file, unlock_file},
     threads::ThreadState,
 };
 

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -1,8 +1,11 @@
+//! Lock files for editing.
+
 use remacs_macros::lisp_fn;
 
 use crate::{
     lisp::LispObject,
-    remacs_sys::{lock_file, unlock_file, Qstringp},
+    remacs_sys::{lock_file, unlock_file},
+    remacs_sys::Qstringp,
     threads::ThreadState,
 };
 

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -1,0 +1,43 @@
+use remacs_macros::lisp_fn;
+
+use crate::{
+    lisp::LispObject,
+    remacs_sys::{lock_file, unlock_file, Qstringp},
+    threads::ThreadState,
+};
+
+/// Lock FILE, if current buffer is modified.
+/// FILE defaults to current buffer's visited file,
+/// or else nothing is done if current buffer isn't visiting a file.
+///
+/// If the option `create-lockfiles' is nil, this does nothing.
+#[lisp_fn(min = "0", name = "lock-buffer")]
+pub fn lock_buffer_lisp(file: LispObject) {
+    let cur_buf = ThreadState::current_buffer_unchecked();
+    let file = if file.is_nil() {
+        cur_buf.truename()
+    } else if file.is_string() {
+        file
+    } else {
+        wrong_type!(Qstringp, file)
+    };
+
+    if cur_buf.modified_since_save() && !file.is_nil() {
+        unsafe { lock_file(file) }
+    }
+}
+
+/// Unlock the file visited in the current buffer.
+/// If the buffer is not modified, this does nothing because the file
+/// should not be locked in that case.
+#[lisp_fn(name = "unlock-buffer")]
+pub fn unlock_buffer_lisp() {
+    let cur_buf = ThreadState::current_buffer_unchecked();
+    let truename = cur_buf.truename();
+
+    if cur_buf.modified_since_save() && truename.is_string() {
+        unsafe { unlock_file(truename) }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/filelock_exports.rs"));

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -14,8 +14,8 @@ use crate::{
 /// or else nothing is done if current buffer isn't visiting a file.
 ///
 /// If the option `create-lockfiles' is nil, this does nothing.
-#[lisp_fn(min = "0", name = "lock-buffer")]
-pub fn lock_buffer_lisp(file: LispObject) {
+#[lisp_fn(min = "0")]
+pub fn lock_buffer(file: LispObject) {
     let cur_buf = ThreadState::current_buffer_unchecked();
     let file = if file.is_nil() {
         cur_buf.truename()

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -86,6 +86,7 @@ mod emacs;
 mod eval;
 mod ffi;
 mod fileio;
+mod filelock;
 mod floatfns;
 mod fns;
 mod fonts;

--- a/src/filelock.c
+++ b/src/filelock.c
@@ -753,38 +753,6 @@ unlock_all_files (void)
 	unlock_file (BVAR (b, file_truename));
     }
 }
-
-DEFUN ("lock-buffer", Flock_buffer, Slock_buffer,
-       0, 1, 0,
-       doc: /* Lock FILE, if current buffer is modified.
-FILE defaults to current buffer's visited file,
-or else nothing is done if current buffer isn't visiting a file.
-
-If the option `create-lockfiles' is nil, this does nothing.  */)
-  (Lisp_Object file)
-{
-  if (NILP (file))
-    file = BVAR (current_buffer, file_truename);
-  else
-    CHECK_STRING (file);
-  if (SAVE_MODIFF < MODIFF
-      && !NILP (file))
-    lock_file (file);
-  return Qnil;
-}
-
-DEFUN ("unlock-buffer", Funlock_buffer, Sunlock_buffer,
-       0, 0, 0,
-       doc: /* Unlock the file visited in the current buffer.
-If the buffer is not modified, this does nothing because the file
-should not be locked in that case.  */)
-  (void)
-{
-  if (SAVE_MODIFF < MODIFF
-      && STRINGP (BVAR (current_buffer, file_truename)))
-    unlock_file (BVAR (current_buffer, file_truename));
-  return Qnil;
-}
 
 /* Unlock the file visited in buffer BUFFER.  */
 
@@ -835,7 +803,5 @@ syms_of_filelock (void)
 	       doc: /* Non-nil means use lockfiles to avoid editing collisions.  */);
   create_lockfiles = 1;
 
-  defsubr (&Sunlock_buffer);
-  defsubr (&Slock_buffer);
   defsubr (&Sfile_locked_p);
 }

--- a/test/rust_src/src/filelock-tests.el
+++ b/test/rust_src/src/filelock-tests.el
@@ -1,0 +1,46 @@
+;;; filelock-tests.el --- Tests for filelock.rs
+
+;;; Code:
+
+(require 'ert)
+
+(ert-deftest filelock-tests--lock-buffer-base ()
+  "Check lock-buffer base cases"
+  (should (eq nil (lock-buffer)))
+  (should (eq nil (lock-buffer nil)))
+  (should-error (eval '(lock-buffer "foo" "bar")) :type 'wrong-number-of-arguments)
+  (should-error (eval '(lock-buffer 1)) :type 'wrong-type-argument)
+  (should-error (eval '(lock-buffer '("foo"))) :type 'wrong-type-argument)
+  (should-error (eval '(lock-buffer 'bogus)) :type 'wrong-type-argument)
+  (should-error (eval '(lock-buffer t)) :type 'wrong-type-argument))
+
+(ert-deftest filelock-tests--unlock-buffer-base ()
+  "Check unlock-buffer base cases"
+  (should (eq nil (unlock-buffer)))
+  (should-error (eval '(unlock-buffer "foo")) :type 'wrong-number-of-arguments)
+  (should-error (eval '(unlock-buffer nil)) :type 'wrong-number-of-arguments))
+
+(ert-deftest filelock-tests--lock-buffer-current ()
+  "Check locking of current buffer"
+  (let ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test")))
+    (find-file-existing file)
+    (insert "modification")
+    (lock-buffer)
+    (should (eq t (file-locked-p file)))
+    (unlock-buffer)
+    (should (eq nil (file-locked-p file)))))
+
+(ert-deftest filelock-tests--lock-buffer-other ()
+  "Check locking of other file"
+  (let ((file (make-temp-file "filelock-tests--other-" nil ".txt" "test"))
+        (other (make-temp-file "filelock-tests--other-to-lock-" nil ".txt" "to-lock")))
+    (find-file-existing file)
+    (insert "modification")
+    (lock-buffer other)
+    ; I don’t understand this but it replicates GNU Emacs behavior
+    (should (eq t (file-locked-p file)))
+    (should (eq t (file-locked-p other)))
+    (unlock-buffer)
+    (should (eq nil (file-locked-p file)))
+    (should (eq t (file-locked-p other)))))
+


### PR DESCRIPTION
Fixes #928. Introduces `filelock.rs`.

Added `LispBufferRef.modified_since_save()` since grepping for `SAVE_MODIFF` in `src` shows it could be useful in other places as well.

