### PR TITLE
[WIP] Port trace-redisplay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
         - travis_wait rustup install $(cat rust-toolchain)
       script:
         # The -Wno-error allows MacOS code deprecation warnings to remain warnings.
-        - ./autogen.sh && RUSTFLAGS="-Dwarnings" WERROR_CFLAGS='-Werror -Wno-error=deprecated-declarations' ./configure
+        - ./autogen.sh && RUSTFLAGS="-Dwarnings" WERROR_CFLAGS='-Werror -Wno-error=deprecated-declarations' ./configure --enable-checking=glyphs
         - make -j 3 && echo '==> Running tests' && make check
     -
       <<: *FULL_TEST

--- a/configure.ac
+++ b/configure.ac
@@ -497,34 +497,28 @@ CARGO_CHECKING_FEATURES=""
 if test x$ac_enable_checking != x ; then
   AC_DEFINE(ENABLE_CHECKING, 1,
 [Define to 1 if expensive run-time data type and consistency checks are enabled.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"checking\", "
 fi
 if test x$ac_gc_check_stringbytes != x ; then
   AC_DEFINE(GC_CHECK_STRING_BYTES, 1,
 [Define this temporarily to hunt a bug.  If defined, the size of
    strings is redundantly recorded in sdata structures so that it can
    be compared to the sizes recorded in Lisp strings.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-bytes\", "
 fi
 if test x$ac_gc_check_string_overrun != x ; then
   AC_DEFINE(GC_CHECK_STRING_OVERRUN, 1,
 [Define this to check for short string overrun.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-overrun\", "
 fi
 if test x$ac_gc_check_string_free_list != x ; then
   AC_DEFINE(GC_CHECK_STRING_FREE_LIST, 1,
 [Define this to check the string free list.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-free-list\", "
 fi
 if test x$ac_xmalloc_overrun != x ; then
   AC_DEFINE(XMALLOC_OVERRUN_CHECK, 1,
 [Define this to check for malloc buffer overrun.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"xmalloc-overrun-check\", "
 fi
 if test x$ac_gc_check_cons_list != x ; then
   AC_DEFINE(GC_CHECK_CONS_LIST, 1,
 [Define this to check for errors in cons list.])
-  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-cons-list\", "
 fi
 if test x$ac_glyphs_debug != x ; then
   AC_DEFINE(GLYPH_DEBUG, 1,

--- a/configure.ac
+++ b/configure.ac
@@ -493,36 +493,45 @@ do
 done
 IFS="$ac_save_IFS"
 
+CARGO_CHECKING_FEATURES=""
 if test x$ac_enable_checking != x ; then
   AC_DEFINE(ENABLE_CHECKING, 1,
 [Define to 1 if expensive run-time data type and consistency checks are enabled.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"checking\", "
 fi
 if test x$ac_gc_check_stringbytes != x ; then
   AC_DEFINE(GC_CHECK_STRING_BYTES, 1,
 [Define this temporarily to hunt a bug.  If defined, the size of
    strings is redundantly recorded in sdata structures so that it can
    be compared to the sizes recorded in Lisp strings.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-bytes\", "
 fi
 if test x$ac_gc_check_string_overrun != x ; then
   AC_DEFINE(GC_CHECK_STRING_OVERRUN, 1,
 [Define this to check for short string overrun.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-overrun\", "
 fi
 if test x$ac_gc_check_string_free_list != x ; then
   AC_DEFINE(GC_CHECK_STRING_FREE_LIST, 1,
 [Define this to check the string free list.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-string-free-list\", "
 fi
 if test x$ac_xmalloc_overrun != x ; then
   AC_DEFINE(XMALLOC_OVERRUN_CHECK, 1,
 [Define this to check for malloc buffer overrun.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"xmalloc-overrun-check\", "
 fi
 if test x$ac_gc_check_cons_list != x ; then
   AC_DEFINE(GC_CHECK_CONS_LIST, 1,
 [Define this to check for errors in cons list.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"gc-check-cons-list\", "
 fi
 if test x$ac_glyphs_debug != x ; then
   AC_DEFINE(GLYPH_DEBUG, 1,
 [Define this to enable glyphs debugging code.])
+  CARGO_CHECKING_FEATURES="${CARGO_CHECKING_FEATURES}\"glyph-debug\", "
 fi
+AC_SUBST(CARGO_CHECKING_FEATURES)
 
 dnl The name of this option is unfortunate.  It predates, and has no
 dnl relation to, the "sampling-based elisp profiler" added in 24.3.

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -74,17 +74,5 @@ window-system-w32 = []
 # Treat warnings as a build error on Travis.
 strict = []
 
-# Expensive run-time data type and consistency checks.
-checking = []
-# Enable this temporarily to hunt a bug.  If enabled, the size of
-# strings is redundantly recorded in sdata structures so that it can
-# be compared to the sizes recorded in Lisp strings.
-gc-check-string-bytes = []
-# Enable this to check for short string overrun.
-gc-check-string-free-list = []
-# Enable this to check for malloc buffer overrun.
-xmalloc-overrun-check = []
-# Enable this to check for errors in cons list.
-gc-check-cons-list = []
 # Enable glyphs debugging code.
 glyph-debug = []

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -53,7 +53,10 @@ panic = "abort"
 panic = "abort"
 
 [features]
-default = [@CARGO_DEFAULT_FEATURES@]
+default = [
+  @CARGO_DEFAULT_FEATURES@
+  @CARGO_CHECKING_FEATURES@
+]
 # Use unexec crate on Mac
 unexecmacosx = ["alloc_unexecmacosx"]
 # unexec everywhere else
@@ -70,3 +73,18 @@ window-system-nextstep = []
 window-system-w32 = []
 # Treat warnings as a build error on Travis.
 strict = []
+
+# Expensive run-time data type and consistency checks.
+checking = []
+# Enable this temporarily to hunt a bug.  If enabled, the size of
+# strings is redundantly recorded in sdata structures so that it can
+# be compared to the sizes recorded in Lisp strings.
+gc-check-string-bytes = []
+# Enable this to check for short string overrun.
+gc-check-string-free-list = []
+# Enable this to check for malloc buffer overrun.
+xmalloc-overrun-check = []
+# Enable this to check for errors in cons list.
+gc-check-cons-list = []
+# Enable glyphs debugging code.
+glyph-debug = []

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -122,6 +122,7 @@ mod util;
 mod vectors;
 mod window_configuration;
 mod windows;
+mod xdisp;
 mod xfaces;
 mod xml;
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -749,11 +749,12 @@ extern "C" {
 }
 
 macro_rules! export_lisp_fns {
-    ($($f:ident),+) => {
+    ($($(#[$($meta:meta),*])* $f:ident),+) => {
         pub fn rust_init_syms() {
+            #[allow(unused_unsafe)] // just in case the block is empty
             unsafe {
                 $(
-                    crate::lisp::defsubr(concat_idents!(S, $f).as_ptr());
+                    $(#[$($meta),*])* crate::lisp::defsubr(concat_idents!(S, $f).as_ptr());
                 )+
             }
         }

--- a/rust_src/src/xdisp.rs
+++ b/rust_src/src/xdisp.rs
@@ -1,5 +1,8 @@
 //! Display generation from window structure and buffer text.
 
+// Remove the feature check when this file gains functions
+// that are not guarded by it.
+#[cfg(feature = "glyph-debug")]
 use remacs_macros::lisp_fn;
 
 #[cfg(feature = "glyph-debug")]

--- a/rust_src/src/xdisp.rs
+++ b/rust_src/src/xdisp.rs
@@ -21,7 +21,4 @@ pub fn trace_redisplay(arg: Option<InteractiveNumericPrefix>) {
     }
 }
 
-// Remove the feature check when this file gains functions
-// that are not guarded by it.
-#[cfg(feature = "glyph-debug")]
 include!(concat!(env!("OUT_DIR"), "/xdisp_exports.rs"));

--- a/rust_src/src/xdisp.rs
+++ b/rust_src/src/xdisp.rs
@@ -2,20 +2,23 @@
 
 use remacs_macros::lisp_fn;
 
-use crate::remacs_sys::{trace_redisplay_p, EmacsInt};
+#[cfg(feature = "glyph-debug")]
+use crate::{interactive::InteractiveNumericPrefix, remacs_sys::trace_redisplay_p};
 
 /// Toggle tracing of redisplay.
 /// With ARG, turn tracing on if and only if ARG is positive.
 #[cfg(feature = "glyph-debug")]
 #[lisp_fn(min = "0", intspec = "P")]
-pub fn trace_redisplay(arg: Option<EmacsInt>) {
+pub fn trace_redisplay(arg: Option<InteractiveNumericPrefix>) {
     unsafe {
         match arg {
             None => trace_redisplay_p = !trace_redisplay_p,
-            Some(n) if n > 0 => trace_redisplay_p = true,
-            _ => trace_redisplay_p = false,
+            Some(n) => trace_redisplay_p = n.unwrap() > 0,
         }
     }
 }
 
+// Remove the feature check when this file gains functions
+// that are not guarded by it.
+#[cfg(feature = "glyph-debug")]
 include!(concat!(env!("OUT_DIR"), "/xdisp_exports.rs"));

--- a/rust_src/src/xdisp.rs
+++ b/rust_src/src/xdisp.rs
@@ -1,0 +1,21 @@
+//! Display generation from window structure and buffer text.
+
+use remacs_macros::lisp_fn;
+
+use crate::remacs_sys::{trace_redisplay_p, EmacsInt};
+
+/// Toggle tracing of redisplay.
+/// With ARG, turn tracing on if and only if ARG is positive.
+#[cfg(feature = "glyph-debug")]
+#[lisp_fn(min = "0", intspec = "P")]
+pub fn trace_redisplay(arg: Option<EmacsInt>) {
+    unsafe {
+        match arg {
+            None => trace_redisplay_p = !trace_redisplay_p,
+            Some(n) if n > 0 => trace_redisplay_p = true,
+            _ => trace_redisplay_p = false,
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/xdisp_exports.rs"));

--- a/src/xdisp.c
+++ b/src/xdisp.c
@@ -19612,23 +19612,6 @@ do nothing.  */)
 }
 
 
-DEFUN ("trace-redisplay", Ftrace_redisplay, Strace_redisplay, 0, 1, "P",
-       doc: /* Toggle tracing of redisplay.
-With ARG, turn tracing on if and only if ARG is positive.  */)
-  (Lisp_Object arg)
-{
-  if (NILP (arg))
-    trace_redisplay_p = !trace_redisplay_p;
-  else
-    {
-      arg = Fprefix_numeric_value (arg);
-      trace_redisplay_p = XINT (arg) > 0;
-    }
-
-  return Qnil;
-}
-
-
 DEFUN ("trace-to-stderr", Ftrace_to_stderr, Strace_to_stderr, 1, MANY, "",
        doc: /* Like `format', but print result to stderr.
 usage: (trace-to-stderr STRING &rest OBJECTS)  */)
@@ -32394,7 +32377,6 @@ They are still logged to the *Messages* buffer.  */);
   defsubr (&Sdump_glyph_matrix);
   defsubr (&Sdump_glyph_row);
   defsubr (&Sdump_tool_bar_row);
-  defsubr (&Strace_redisplay);
   defsubr (&Strace_to_stderr);
 #endif
 #ifdef HAVE_WINDOW_SYSTEM

--- a/test/rust_src/src/xdisp-tests.el
+++ b/test/rust_src/src/xdisp-tests.el
@@ -5,10 +5,11 @@
 (require 'ert)
 
 (ert-deftest xdisp-tests--trace-redisplay-base ()
+  "Check (trace-redisplay) base cases.
+   Only run when configured with --enable-checks=glyphs or equivalent."
   (when (fboundp 'trace-redisplay)
-    (should-error (trace-redisplay 'bogus))
-    (should-error (trace-redisplay "wrong"))
-    (should-error (trace-redisplay t))
+    (should-error (trace-redisplay 1 2))
+    (should-error (trace-redisplay nil 2))
 
     (should (eq nil (trace-redisplay)))
     (should (eq nil (trace-redisplay nil)))

--- a/test/rust_src/src/xdisp-tests.el
+++ b/test/rust_src/src/xdisp-tests.el
@@ -1,0 +1,17 @@
+;;; xdisp-tests.el --- Tests for xdisp.rs
+
+;;; Code:
+
+(require 'ert)
+
+(ert-deftest xdisp-tests--trace-redisplay-base ()
+  (when (fboundp 'trace-redisplay)
+    (should-error (trace-redisplay 'bogus))
+    (should-error (trace-redisplay "wrong"))
+    (should-error (trace-redisplay t))
+
+    (should (eq nil (trace-redisplay)))
+    (should (eq nil (trace-redisplay nil)))
+    (should (eq nil (trace-redisplay -1)))
+    (should (eq nil (trace-redisplay 0)))
+    (should (eq nil (trace-redisplay 1)))))

--- a/test/rust_src/src/xdisp-tests.el
+++ b/test/rust_src/src/xdisp-tests.el
@@ -11,8 +11,8 @@
     (should-error (trace-redisplay 1 2))
     (should-error (trace-redisplay nil 2))
 
-    (should (eq nil (trace-redisplay)))
-    (should (eq nil (trace-redisplay nil)))
-    (should (eq nil (trace-redisplay -1)))
-    (should (eq nil (trace-redisplay 0)))
-    (should (eq nil (trace-redisplay 1)))))
+    (should-not (trace-redisplay))
+    (should-not (trace-redisplay nil))
+    (should-not (trace-redisplay -1))
+    (should-not (trace-redisplay 0))
+    (should-not (trace-redisplay 1))))


### PR DESCRIPTION
Fixes #1014.

Added Rust features for all of the Emacs checking flags while at it. Let me know if they are not (going to be) needed and I’ll just drop them.