### PR TITLE
Replace `clippy::cyclomatic_complexity` with `clippy::cognitive_complexity`

### DIFF
--- a/rust_src/remacs-lib/docfile.rs
+++ b/rust_src/remacs-lib/docfile.rs
@@ -1,6 +1,6 @@
 //! Extract Rust docstrings from source files for Emacs' DOC file.
 
-#![allow(clippy::cyclomatic_complexity)]
+#![allow(clippy::cognitive_complexity)]
 
 use libc::{c_char, c_int};
 use regex::Regex;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::cyclomatic_complexity)]
+#![allow(clippy::cognitive_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
Resolves #1402 

This lint rule has been renamed in the latest Clippy version

These are the only two references to the name I found by grepping the code.

I tested it by temporarily removing these lines and running `cargo clippy` again. This caused cognitive complexity warnings to be displayed when they weren't before.

I'm pretty new to both Rust and the emacs source code, but this is something I figured I could handle :). 