### PR TITLE
Update README to include link to Gitter Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,4 +297,4 @@ Pull requests welcome, no copyright assignment required. This project is under t
 [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct).
 
 There's lots to do! We keep a list of [low hanging fruit](https://github.com/Wilfred/remacs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) here so you can easily choose
-one. You can find information in the [Porting cookbook](https://github.com/Wilfred/remacs/wiki/Porting-cookbook) or ask for help in our gitter channel.
+one. You can find information in the [Porting cookbook](https://github.com/Wilfred/remacs/wiki/Porting-cookbook) or ask for help in our [Gitter channel](https://gitter.im/remacs-discuss/Lobby).


### PR DESCRIPTION
The README now includes a link to the Gitter channel