### PR TITLE
Make rustize-emacs function comment regex reluctant

### DIFF
--- a/rust_src/admin/rustize-emacs
+++ b/rust_src/admin/rustize-emacs
@@ -137,7 +137,7 @@ def parse_c_definition(c_code):
     if match:
         return ('defun', match.groupdict())
 
-    c_func_regex = re.compile(r'''^\s*(?:/\*\s*(?P<comment>.+)\*/)?\s*(?:static|extern)?\s*(?P<return_type>\w+)\s*(?P<func_name>[^\)]+)\s+\((?P<func_args>[^\)]+)\)
+    c_func_regex = re.compile(r'''^\s*(?:/\*\s*(?P<comment>.+?)\*/)?\s*(?:static|extern)?\s*(?P<return_type>\w+)\s*(?P<func_name>[^\)]+)\s+\((?P<func_args>[^\)]+)\)
 (?P<code>.+)''', re.DOTALL)
 
     match = c_func_regex.match(c_code)


### PR DESCRIPTION
While working on #1408 I noticed the script crashes when run on [`set_window_hscroll`][swh] in [`src/window.c`][window], because the [`<comment>`][regex] group consumes both the comment before the function definition and the two comments inside the function body. This fixes the crash by making the `<comment>` group reluctant instead of greedy, so it consumes as few characters as possible.

[regex]: https://github.com/remacs/remacs/blob/master/rust_src/admin/rustize-emacs#L140
[swh]: https://github.com/remacs/remacs/blob/master/src/window.c#L519
[window]: https://github.com/remacs/remacs/blob/master/src/window.c