### PR TITLE
Port set-window-hscroll

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -513,44 +513,6 @@ WINDOW must be a live window and defaults to the selected one.  */)
   return (make_number (WINDOW_SCROLL_BAR_AREA_HEIGHT (decode_live_window (window))));
 }
 
-/* Set W's horizontal scroll amount to HSCROLL clipped to a reasonable
-   range, returning the new amount as a fixnum.  */
-Lisp_Object
-set_window_hscroll (struct window *w, EMACS_INT hscroll)
-{
-  /* Horizontal scrolling has problems with large scroll amounts.
-     It's too slow with long lines, and even with small lines the
-     display can be messed up.  For now, though, impose only the limits
-     required by the internal representation: horizontal scrolling must
-     fit in fixnum (since it's visible to Elisp) and into ptrdiff_t
-     (since it's stored in a ptrdiff_t).  */
-  ptrdiff_t hscroll_max = min (MOST_POSITIVE_FIXNUM, PTRDIFF_MAX);
-  ptrdiff_t new_hscroll = clip_to_bounds (0, hscroll, hscroll_max);
-
-  /* Prevent redisplay shortcuts when changing the hscroll.  */
-  if (w->hscroll != new_hscroll)
-    XBUFFER (w->contents)->prevent_redisplay_optimizations_p = true;
-
-  w->hscroll = new_hscroll;
-  w->suspend_auto_hscroll = true;
-
-  return make_number (new_hscroll);
-}
-
-DEFUN ("set-window-hscroll", Fset_window_hscroll, Sset_window_hscroll, 2, 2, 0,
-       doc: /* Set number of columns WINDOW is scrolled from left margin to NCOL.
-WINDOW must be a live window and defaults to the selected one.
-Clip the number to a reasonable value if out of range.
-Return the new number.  NCOL should be zero or positive.
-
-Note that if `automatic-hscrolling' is non-nil, you cannot scroll the
-window so that the location of point moves off-window.  */)
-  (Lisp_Object window, Lisp_Object ncol)
-{
-  CHECK_NUMBER (ncol);
-  return set_window_hscroll (decode_live_window (window), XINT (ncol));
-}
-
 /* Test if the character at column X, row Y is within window W.
    If it is not, return ON_NOTHING;
    if it is on the window's vertical divider, return
@@ -6277,7 +6239,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sset_window_new_normal);
   defsubr (&Swindow_resize_apply);
   defsubr (&Swindow_resize_apply_total);
-  defsubr (&Sset_window_hscroll);
   defsubr (&Swindow_mode_line_height);
   defsubr (&Swindow_header_line_height);
   defsubr (&Swindow_right_divider_width);

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -152,3 +152,30 @@
     (should (set-window-fringes w1 1 1 nil))
     (should-not (set-window-fringes w1 1 1 nil))
     (should (set-window-fringes w1 1 2 nil))))
+
+(ert-deftest window-hscroll ()
+  "Effectively tests both `window-hscroll' (the getter) and
+  `set-window-hscroll' (the setter)."
+
+  ;; Can we change hscroll on this window?
+  (set-window-hscroll nil 42)
+  (should (= (window-hscroll) 42))
+  (should (= (window-hscroll nil) 42))
+  (set-window-hscroll nil 7)
+  (should (= (window-hscroll) 7))
+  (should (= (window-hscroll nil) 7))
+
+  ;; Can we correctly operate on a different window?
+  (let ((initial-window (selected-window))
+        (other-window (split-window)))
+    (set-window-hscroll initial-window 1337)
+    (set-window-hscroll other-window 4711)
+    (should (= (window-hscroll) 1337))
+    (should (= (window-hscroll initial-window) 1337))
+    (should (= (window-hscroll other-window) 4711))
+    (select-window other-window)
+    (should (= (window-hscroll) 4711))
+    (should (= (window-hscroll initial-window) 1337))
+    (should (= (window-hscroll other-window) 4711))
+    (delete-window other-window)
+    ))

--- a/test/src/window-tests.el
+++ b/test/src/window-tests.el
@@ -26,30 +26,3 @@
       (split-window-vertically)
       (other-window 1)
       (should (< current (window-top-line))))))
-
-(ert-deftest window-hscroll ()
-  "Effectively tests both `window-hscroll' (the getter) and
-  `set-window-hscroll' (the setter)."
-
-  ;; Can we change hscroll on this window?
-  (set-window-hscroll nil 42)
-  (should (= (window-hscroll) 42))
-  (should (= (window-hscroll nil) 42))
-  (set-window-hscroll nil 7)
-  (should (= (window-hscroll) 7))
-  (should (= (window-hscroll nil) 7))
-
-  ;; Can we correctly operate on a different window?
-  (let ((initial-window (selected-window))
-        (other-window (split-window)))
-    (set-window-hscroll initial-window 1337)
-    (set-window-hscroll other-window 4711)
-    (should (= (window-hscroll) 1337))
-    (should (= (window-hscroll initial-window) 1337))
-    (should (= (window-hscroll other-window) 4711))
-    (select-window other-window)
-    (should (= (window-hscroll) 4711))
-    (should (= (window-hscroll initial-window) 1337))
-    (should (= (window-hscroll other-window) 4711))
-    (delete-window other-window)
-    ))

--- a/test/src/window-tests.el
+++ b/test/src/window-tests.el
@@ -26,3 +26,30 @@
       (split-window-vertically)
       (other-window 1)
       (should (< current (window-top-line))))))
+
+(ert-deftest window-hscroll ()
+  "Effectively tests both `window-hscroll' (the getter) and
+  `set-window-hscroll' (the setter)."
+
+  ;; Can we change hscroll on this window?
+  (set-window-hscroll nil 42)
+  (should (= (window-hscroll) 42))
+  (should (= (window-hscroll nil) 42))
+  (set-window-hscroll nil 7)
+  (should (= (window-hscroll) 7))
+  (should (= (window-hscroll nil) 7))
+
+  ;; Can we correctly operate on a different window?
+  (let ((initial-window (selected-window))
+        (other-window (split-window)))
+    (set-window-hscroll initial-window 1337)
+    (set-window-hscroll other-window 4711)
+    (should (= (window-hscroll) 1337))
+    (should (= (window-hscroll initial-window) 1337))
+    (should (= (window-hscroll other-window) 4711))
+    (select-window other-window)
+    (should (= (window-hscroll) 4711))
+    (should (= (window-hscroll initial-window) 1337))
+    (should (= (window-hscroll other-window) 4711))
+    (delete-window other-window)
+    ))


### PR DESCRIPTION
Fixes #1408.

I'm not sure I have the best approach to computing `hscroll_max`, but at least it should be safe - unless I'm mistaken, the only reason the `try_from` call should fail is if `MOST_POSITIVE_FIXNUM` is too big for an `isize`. `std::cmp::max(MOST_POSITIVE_FIXNUM, isize::max_value())` is not applicable since the two arguments are of different types.