### PR TITLE
Port window-pixel-width-before-size-change (and -height)

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1974,10 +1974,9 @@ pub fn set_window_fringes_lisp(
 /// `window-size-change-functions' was run.  It's zero if WINDOW was made
 /// after that.
 #[lisp_fn(min = "0")]
-pub fn window_pixel_width_before_size_change(window: LispWindowValidOrSelected) -> EmacsInt {
-    LispWindowRef::from(window)
-        .pixel_width_before_size_change
-        .into()
+pub fn window_pixel_width_before_size_change(window: LispWindowValidOrSelected) -> i32 {
+    let window: LispWindowRef = window.into();
+    window.pixel_width_before_size_change
 }
 
 /// Return pixel height of window WINDOW before last size changes.
@@ -1987,10 +1986,9 @@ pub fn window_pixel_width_before_size_change(window: LispWindowValidOrSelected) 
 /// `window-size-change-functions' was run.  It's zero if WINDOW was made
 /// after that.
 #[lisp_fn(min = "0")]
-pub fn window_pixel_height_before_size_change(window: LispWindowValidOrSelected) -> EmacsInt {
-    LispWindowRef::from(window)
-        .pixel_height_before_size_change
-        .into()
+pub fn window_pixel_height_before_size_change(window: LispWindowValidOrSelected) -> i32 {
+    let window: LispWindowRef = window.into();
+    window.pixel_height_before_size_change
 }
 
 include!(concat!(env!("OUT_DIR"), "/windows_exports.rs"));

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1967,4 +1967,30 @@ pub fn set_window_fringes_lisp(
     }
 }
 
+/// Return pixel width of window WINDOW before last size changes.
+/// WINDOW must be a valid window and defaults to the selected one.
+///
+/// The return value is the pixel width of WINDOW at the last time
+/// `window-size-change-functions' was run.  It's zero if WINDOW was made
+/// after that.
+#[lisp_fn(min = "0")]
+pub fn window_pixel_width_before_size_change(window: LispWindowValidOrSelected) -> EmacsInt {
+    LispWindowRef::from(window)
+        .pixel_width_before_size_change
+        .into()
+}
+
+/// Return pixel height of window WINDOW before last size changes.
+/// WINDOW must be a valid window and defaults to the selected one.
+///
+/// The return value is the pixel height of WINDOW at the last time
+/// `window-size-change-functions' was run.  It's zero if WINDOW was made
+/// after that.
+#[lisp_fn(min = "0")]
+pub fn window_pixel_height_before_size_change(window: LispWindowValidOrSelected) -> EmacsInt {
+    LispWindowRef::from(window)
+        .pixel_height_before_size_change
+        .into()
+}
+
 include!(concat!(env!("OUT_DIR"), "/windows_exports.rs"));

--- a/src/window.c
+++ b/src/window.c
@@ -429,36 +429,6 @@ vertical combination.  */)
   return WINDOW_HORIZONTAL_COMBINATION_P (w) ? w->contents : Qnil;
 }
 
-DEFUN ("window-pixel-width-before-size-change",
-       Fwindow_pixel_width_before_size_change,
-       Swindow_pixel_width_before_size_change, 0, 1, 0,
-       doc: /* Return pixel width of window WINDOW before last size changes.
-WINDOW must be a valid window and defaults to the selected one.
-
-The return value is the pixel width of WINDOW at the last time
-`window-size-change-functions' was run.  It's zero if WINDOW was made
-after that.  */)
-  (Lisp_Object window)
-{
-  return (make_number
-	  (decode_valid_window (window)->pixel_width_before_size_change));
-}
-
-DEFUN ("window-pixel-height-before-size-change",
-       Fwindow_pixel_height_before_size_change,
-       Swindow_pixel_height_before_size_change, 0, 1, 0,
-       doc: /* Return pixel height of window WINDOW before last size changes.
-WINDOW must be a valid window and defaults to the selected one.
-
-The return value is the pixel height of WINDOW at the last time
-`window-size-change-functions' was run.  It's zero if WINDOW was made
-after that.  */)
-  (Lisp_Object window)
-{
-  return (make_number
-	  (decode_valid_window (window)->pixel_height_before_size_change));
-}
-
 DEFUN ("window-mode-line-height", Fwindow_mode_line_height,
        Swindow_mode_line_height, 0, 1, 0,
        doc: /* Return the height in pixels of WINDOW's mode-line.
@@ -6233,8 +6203,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Spos_visible_in_window_p);
   defsubr (&Swindow_line_height);
   defsubr (&Swindow_left_child);
-  defsubr (&Swindow_pixel_width_before_size_change);
-  defsubr (&Swindow_pixel_height_before_size_change);
   defsubr (&Sset_window_new_pixel);
   defsubr (&Sset_window_new_normal);
   defsubr (&Swindow_resize_apply);

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -179,3 +179,13 @@
     (should (= (window-hscroll other-window) 4711))
     (delete-window other-window)
     ))
+
+;; TODO: make proper tests for this function when we will be able to change 
+;; frames inside tests (see https://github.com/remacs/remacs/issues/1429).
+(ert-deftest window-pixel-width-before-size-change ()
+  (window-pixel-width-before-size-change))
+
+;; TODO: make proper tests for this function when we will be able to change 
+;; frames inside tests (see https://github.com/remacs/remacs/issues/1429).
+(ert-deftest window-pixel-height-before-size-change ()
+  (window-pixel-height-before-size-change))


### PR DESCRIPTION
Fixes https://github.com/remacs/remacs/issues/1429

Currently lacks tests due to problem with ert: it doesn't actually change `window-pixel-width-before-size-change` during tests (probably because tests doesn't change frame and thus `window-size-change-functions` not invoked).