### PR TITLE
Port read-chars, read-event and read-char-exclusive from lread.c

### DIFF
--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -22,7 +22,7 @@ use crate::{
     remacs_sys,
     remacs_sys::infile,
     remacs_sys::{
-        block_input, build_string, getc_unlocked, make_number, maybe_quit, read_filtered_event,
+        block_input, build_string, getc_unlocked, maybe_quit, read_filtered_event,
         read_internal_start, readevalloop, specbind, staticpro, symbol_redirect, unblock_input,
     },
     remacs_sys::{globals, EmacsInt},
@@ -335,7 +335,7 @@ pub fn read_char(
     prompt: LispObject,
     inherit_input_method: LispObject,
     seconds: LispObject,
-) -> LispObject {
+) -> Option<EmacsInt> {
     if !prompt.is_nil() {
         message_with_string!("%s", prompt, false);
     }
@@ -343,10 +343,9 @@ pub fn read_char(
     let val =
         unsafe { read_filtered_event(true, true, true, !inherit_input_method.is_nil(), seconds) };
 
-    if val.is_nil() {
-        Qnil
-    } else {
-        unsafe { make_number(char_resolve_modifier_mask(val.into())) }
+    match val.into() {
+        Some(num) => Some(char_resolve_modifier_mask(num)),
+        None => None,
     }
 }
 def_lisp_sym!(Qread_char, "read-char");
@@ -370,7 +369,7 @@ pub fn read_event(
         message_with_string!("%s", prompt, false);
     }
 
-    unsafe { read_filtered_event(false, false, false, inherit_input_method.is_nil(), seconds) }
+    unsafe { read_filtered_event(false, false, false, !inherit_input_method.is_nil(), seconds) }
 }
 
 /// Read a character from the command input (keyboard or macro).
@@ -391,7 +390,7 @@ pub fn read_char_exclusive(
     prompt: LispObject,
     inherit_input_method: LispObject,
     seconds: LispObject,
-) -> LispObject {
+) -> Option<EmacsInt> {
     if !prompt.is_nil() {
         message_with_string!("%s", prompt, false);
     }
@@ -399,10 +398,9 @@ pub fn read_char_exclusive(
     let val =
         unsafe { read_filtered_event(true, true, false, !inherit_input_method.is_nil(), seconds) };
 
-    if val.is_nil() {
-        Qnil
-    } else {
-        unsafe { make_number(char_resolve_modifier_mask(val.into())) }
+    match val.into() {
+        Some(num) => Some(char_resolve_modifier_mask(num)),
+        None => None,
     }
 }
 

--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -351,4 +351,59 @@ pub fn read_char(
 }
 def_lisp_sym!(Qread_char, "read-char");
 
+/// Read an event object from the input stream.
+/// If the optional argument PROMPT is non-nil, display that as a prompt.
+/// If the optional argument INHERIT-INPUT-METHOD is non-nil and some
+/// input method is turned on in the current buffer, that input method
+/// is used for reading a character.
+/// If the optional argument SECONDS is non-nil, it should be a number
+/// specifying the maximum number of seconds to wait for input.  If no
+/// input arrives in that time, return nil.  SECONDS may be a
+/// floating-point value.
+#[lisp_fn(min = "0")]
+pub fn read_event(
+    prompt: LispObject,
+    inherit_input_method: LispObject,
+    seconds: LispObject,
+) -> LispObject {
+    if !prompt.is_nil() {
+        message_with_string!("%s", prompt, false);
+    }
+
+    unsafe { read_filtered_event(false, false, false, inherit_input_method.is_nil(), seconds) }
+}
+
+/// Read a character from the command input (keyboard or macro).
+/// It is returned as a number.  Non-character events are ignored.
+/// If the character has modifiers, they are resolved and reflected to the
+/// character code if possible (e.g. C-SPC -> 0).
+///
+/// If the optional argument PROMPT is non-nil, display that as a prompt.
+/// If the optional argument INHERIT-INPUT-METHOD is non-nil and some
+/// input method is turned on in the current buffer, that input method
+/// is used for reading a character.
+/// If the optional argument SECONDS is non-nil, it should be a number
+/// specifying the maximum number of seconds to wait for input.  If no
+/// input arrives in that time, return nil.  SECONDS may be a
+/// floating-point value.
+#[lisp_fn(min = "0")]
+pub fn read_char_exclusive(
+    prompt: LispObject,
+    inherit_input_method: LispObject,
+    seconds: LispObject,
+) -> LispObject {
+    if !prompt.is_nil() {
+        message_with_string!("%s", prompt, false);
+    }
+
+    let val =
+        unsafe { read_filtered_event(true, true, false, !inherit_input_method.is_nil(), seconds) };
+
+    if val.is_nil() {
+        Qnil
+    } else {
+        unsafe { make_number(char_resolve_modifier_mask(val.into())) }
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/lread_exports.rs"));

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -3925,6 +3925,9 @@ extern ptrdiff_t evxprintf (char **, ptrdiff_t *, char const *, ptrdiff_t,
   ATTRIBUTE_FORMAT_PRINTF (5, 0);
 
 /* Defined in lread.c.  */
+Lisp_Object read_filtered_event (bool no_switch_frame, bool ascii_required,
+                                bool error_nonascii, bool input_method,
+                                Lisp_Object seconds);
 extern Lisp_Object check_obarray (Lisp_Object);
 extern Lisp_Object intern_1 (const char *, ptrdiff_t);
 extern Lisp_Object intern_c_string_1 (const char *, ptrdiff_t);

--- a/src/lread.c
+++ b/src/lread.c
@@ -591,7 +591,7 @@ static void substitute_in_interval (INTERVAL, void *);
    If SECONDS is a number, wait that many seconds for input, and
    return Qnil if no input arrives within that time.  */
 
-static Lisp_Object
+Lisp_Object
 read_filtered_event (bool no_switch_frame, bool ascii_required,
 		     bool error_nonascii, bool input_method, Lisp_Object seconds)
 {
@@ -679,39 +679,6 @@ read_filtered_event (bool no_switch_frame, bool ascii_required,
 #endif
 
   return val;
-}
-
-DEFUN ("read-char", Fread_char, Sread_char, 0, 3, 0,
-       doc: /* Read a character from the command input (keyboard or macro).
-It is returned as a number.
-If the character has modifiers, they are resolved and reflected to the
-character code if possible (e.g. C-SPC -> 0).
-
-If the user generates an event which is not a character (i.e. a mouse
-click or function key event), `read-char' signals an error.  As an
-exception, switch-frame events are put off until non-character events
-can be read.
-If you want to read non-character events, or ignore them, call
-`read-event' or `read-char-exclusive' instead.
-
-If the optional argument PROMPT is non-nil, display that as a prompt.
-If the optional argument INHERIT-INPUT-METHOD is non-nil and some
-input method is turned on in the current buffer, that input method
-is used for reading a character.
-If the optional argument SECONDS is non-nil, it should be a number
-specifying the maximum number of seconds to wait for input.  If no
-input arrives in that time, return nil.  SECONDS may be a
-floating-point value.  */)
-  (Lisp_Object prompt, Lisp_Object inherit_input_method, Lisp_Object seconds)
-{
-  Lisp_Object val;
-
-  if (! NILP (prompt))
-    message_with_string ("%s", prompt, 0);
-  val = read_filtered_event (1, 1, 1, ! NILP (inherit_input_method), seconds);
-
-  return (NILP (val) ? Qnil
-	  : make_number (char_resolve_modifier_mask (XINT (val))));
 }
 
 DEFUN ("read-event", Fread_event, Sread_event, 0, 3, 0,
@@ -4424,7 +4391,6 @@ syms_of_lread (void)
   defsubr (&Sget_load_suffixes);
   defsubr (&Sload);
   defsubr (&Seval_buffer);
-  defsubr (&Sread_char);
   defsubr (&Sread_char_exclusive);
   defsubr (&Sread_event);
   defsubr (&Slocate_file_internal);
@@ -4704,7 +4670,6 @@ this variable will become obsolete.  */);
 
   DEFSYM (Qcurrent_load_list, "current-load-list");
   DEFSYM (Qstandard_input, "standard-input");
-  DEFSYM (Qread_char, "read-char");
   DEFSYM (Qget_file_char, "get-file-char");
 
   /* Used instead of Qget_file_char while loading *.elc files compiled

--- a/src/lread.c
+++ b/src/lread.c
@@ -681,53 +681,6 @@ read_filtered_event (bool no_switch_frame, bool ascii_required,
   return val;
 }
 
-DEFUN ("read-event", Fread_event, Sread_event, 0, 3, 0,
-       doc: /* Read an event object from the input stream.
-If the optional argument PROMPT is non-nil, display that as a prompt.
-If the optional argument INHERIT-INPUT-METHOD is non-nil and some
-input method is turned on in the current buffer, that input method
-is used for reading a character.
-If the optional argument SECONDS is non-nil, it should be a number
-specifying the maximum number of seconds to wait for input.  If no
-input arrives in that time, return nil.  SECONDS may be a
-floating-point value.  */)
-  (Lisp_Object prompt, Lisp_Object inherit_input_method, Lisp_Object seconds)
-{
-  if (! NILP (prompt))
-    message_with_string ("%s", prompt, 0);
-  return read_filtered_event (0, 0, 0, ! NILP (inherit_input_method), seconds);
-}
-
-DEFUN ("read-char-exclusive", Fread_char_exclusive, Sread_char_exclusive, 0, 3, 0,
-       doc: /* Read a character from the command input (keyboard or macro).
-It is returned as a number.  Non-character events are ignored.
-If the character has modifiers, they are resolved and reflected to the
-character code if possible (e.g. C-SPC -> 0).
-
-If the optional argument PROMPT is non-nil, display that as a prompt.
-If the optional argument INHERIT-INPUT-METHOD is non-nil and some
-input method is turned on in the current buffer, that input method
-is used for reading a character.
-If the optional argument SECONDS is non-nil, it should be a number
-specifying the maximum number of seconds to wait for input.  If no
-input arrives in that time, return nil.  SECONDS may be a
-floating-point value.  */)
-  (Lisp_Object prompt, Lisp_Object inherit_input_method, Lisp_Object seconds)
-{
-  Lisp_Object val;
-
-  if (! NILP (prompt))
-    message_with_string ("%s", prompt, 0);
-
-  val = read_filtered_event (1, 1, 0, ! NILP (inherit_input_method), seconds);
-
-  return (NILP (val) ? Qnil
-	  : make_number (char_resolve_modifier_mask (XINT (val))));
-}
-
-
-
-
 /* Return true if the lisp code read using READCHARFUN defines a non-nil
    `lexical-binding' file variable.  After returning, the stream is
    positioned following the first line, if it is a comment or #! line,
@@ -4391,8 +4344,6 @@ syms_of_lread (void)
   defsubr (&Sget_load_suffixes);
   defsubr (&Sload);
   defsubr (&Seval_buffer);
-  defsubr (&Sread_char_exclusive);
-  defsubr (&Sread_event);
   defsubr (&Slocate_file_internal);
 
   DEFVAR_LISP ("obarray", Vobarray,


### PR DESCRIPTION
These three small functions are pretty much direct translations of their C counterparts, and all make use of the much more complex `read_filtered_event` C function, which is definitely beyond my ability to port. 

Closes #923 .