### PR TITLE
Add comparisons for lisp strings with native types

### DIFF
--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -193,9 +193,15 @@ impl PartialEq<&[u8]> for LispStringRef {
     }
 }
 
-impl PartialEq<&str> for LispStringRef {
-    fn eq(&self, other: &&str) -> bool {
+impl<'a> PartialEq<&'a str> for LispStringRef {
+    fn eq(&self, other: &&'a str) -> bool {
         self.as_slice() == other.as_bytes()
+    }
+}
+
+impl PartialEq<String> for LispStringRef {
+    fn eq(&self, other: &String) -> bool {
+        self == &other.as_str()
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -187,6 +187,18 @@ impl LispStringRef {
     }
 }
 
+impl PartialEq<&[u8]> for LispStringRef {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl PartialEq<&str> for LispStringRef {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_slice() == other.as_bytes()
+    }
+}
+
 impl LispStructuralEqual for LispStringRef {
     fn equal(
         &self,

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -231,8 +231,19 @@ fn str_equality() {
 fn str_foreign_equality() {
     let lisp_str = mock_unibyte_string!("Hello World").force_string();
     let rust_str = String::from("Hello World");
-    assert!(lisp_str == rust_str.as_str());
-    assert!(lisp_str == rust_str.as_bytes());
+
+    assert_eq!(lisp_str, rust_str);
+    assert_eq!(lisp_str, rust_str.as_str());
+    assert_eq!(lisp_str, rust_str.as_bytes());
+
+    let lisp_utf_str = mock_multibyte_string!("Hëllö Wørld").force_string();
+    let rust_utf_str = "Hëllö Wørld";
+    let lisp_utf_str2 = mock_unibyte_string!("こんにちはｺﾝﾆﾁﾊ").force_string();
+    let rust_utf_str2 = "こんにちはｺﾝﾆﾁﾊ";
+
+    assert_eq!(lisp_utf_str, rust_utf_str);
+    assert_ne!(lisp_utf_str, rust_str);
+    assert_eq!(lisp_utf_str2, rust_utf_str2);
 }
 
 #[test]

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -228,6 +228,14 @@ fn str_equality() {
 }
 
 #[test]
+fn str_foreign_equality() {
+    let lisp_str = mock_unibyte_string!("Hello World").force_string();
+    let rust_str = String::from("Hello World");
+    assert!(lisp_str == rust_str.as_str());
+    assert!(lisp_str == rust_str.as_bytes());
+}
+
+#[test]
 fn test_stringlessp() {
     let string = mock_unibyte_string!("Hello World");
     let string2 = mock_unibyte_string!("World Hello");


### PR DESCRIPTION
I'd like to have a `PartialEq` implementation that works for both `&str` and `&String`, but `PartialEq<Deref<Target=str>>` doesn't do the trick. Any advice here would be appreciated.

And feel free to bikeshed about the test name.

Closes #1291.