### PR TITLE
Port clear-charset-maps

### DIFF
--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -4,7 +4,6 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     hashtable::{HashLookupResult, LispHashTableRef},
-    libc::c_int,
     lisp::LispObject,
     remacs_sys::temp_charset_work,
     remacs_sys::Foptimize_char_table,

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -7,8 +7,8 @@ use crate::{
     hashtable::{HashLookupResult, LispHashTableRef},
     lisp::LispObject,
     remacs_sys::temp_charset_work,
-    remacs_sys::Foptimize_char_table,
     remacs_sys::Qnil,
+    remacs_sys::{xfree, Foptimize_char_table},
     remacs_sys::{Vchar_unify_table, Vcharset_hash_table},
 };
 
@@ -28,6 +28,7 @@ impl LispObject {
 #[lisp_fn]
 pub fn clear_charset_maps() {
     unsafe {
+        xfree(temp_charset_work as *mut libc::c_void);
         temp_charset_work = ptr::null_mut();
 
         if Vchar_unify_table.is_char_table() {

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -4,8 +4,12 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     hashtable::{HashLookupResult, LispHashTableRef},
+    libc::c_int,
     lisp::LispObject,
-    remacs_sys::Vcharset_hash_table,
+    remacs_sys::temp_charset_work,
+    remacs_sys::Foptimize_char_table,
+    remacs_sys::Qnil,
+    remacs_sys::{Vchar_unify_table, Vcharset_hash_table},
 };
 
 impl LispObject {
@@ -14,6 +18,46 @@ impl LispObject {
         match h_ref.lookup(self) {
             HashLookupResult::Found(_) => true,
             HashLookupResult::Missing(_) => false,
+        }
+    }
+}
+
+unsafe fn set_temp_charset_work_encoder(c: c_int, code: u16) {
+    if code == 0 {
+        (*temp_charset_work).zero_index_char = c;
+    } else if c < 0x20000 {
+        (*temp_charset_work).table.encoder[c as usize] = code;
+    } else {
+        (*temp_charset_work).table.encoder[c as usize - 0x10000] = code
+    }
+}
+
+unsafe fn get_temp_charset_work_encoder(c: c_int) -> c_int {
+    if c == (*temp_charset_work).zero_index_char {
+        0
+    } else if c < 0x20000 {
+        if (*temp_charset_work).table.encoder[c as usize] != 0 {
+            i32::from((*temp_charset_work).table.encoder[c as usize])
+        } else {
+            -1
+        }
+    } else if (*temp_charset_work).table.encoder[c as usize - 0x10000] != 0 {
+        i32::from((*temp_charset_work).table.encoder[c as usize - 0x10000])
+    } else {
+        -1
+    }
+}
+
+/// Internal use only.
+/// Clear temporary charset mapping tables.
+/// It should be called only from temacs invoked for dumping.
+#[lisp_fn]
+pub fn clear_charset_maps() {
+    unsafe {
+        *temp_charset_work = Default::default();
+
+        if Vchar_unify_table.is_char_table() {
+            Foptimize_char_table(Vchar_unify_table, Qnil);
         }
     }
 }

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -22,32 +22,6 @@ impl LispObject {
     }
 }
 
-unsafe fn set_temp_charset_work_encoder(c: c_int, code: u16) {
-    if code == 0 {
-        (*temp_charset_work).zero_index_char = c;
-    } else if c < 0x20000 {
-        (*temp_charset_work).table.encoder[c as usize] = code;
-    } else {
-        (*temp_charset_work).table.encoder[c as usize - 0x10000] = code
-    }
-}
-
-unsafe fn get_temp_charset_work_encoder(c: c_int) -> c_int {
-    if c == (*temp_charset_work).zero_index_char {
-        0
-    } else if c < 0x20000 {
-        if (*temp_charset_work).table.encoder[c as usize] != 0 {
-            i32::from((*temp_charset_work).table.encoder[c as usize])
-        } else {
-            -1
-        }
-    } else if (*temp_charset_work).table.encoder[c as usize - 0x10000] != 0 {
-        i32::from((*temp_charset_work).table.encoder[c as usize - 0x10000])
-    } else {
-        -1
-    }
-}
-
 /// Internal use only.
 /// Clear temporary charset mapping tables.
 /// It should be called only from temacs invoked for dumping.

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -29,8 +29,10 @@ impl LispObject {
 #[lisp_fn]
 pub fn clear_charset_maps() {
     unsafe {
-        xfree(temp_charset_work as *mut libc::c_void);
-        temp_charset_work = ptr::null_mut();
+        if !temp_charset_work.is_null() {
+            xfree(temp_charset_work as *mut libc::c_void);
+            temp_charset_work = ptr::null_mut();
+        }
 
         if Vchar_unify_table.is_char_table() {
             Foptimize_char_table(Vchar_unify_table, Qnil);

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -1,7 +1,8 @@
 //! Basic character set support.
 
-use remacs_macros::lisp_fn;
 use std::ptr;
+
+use remacs_macros::lisp_fn;
 
 use crate::{
     hashtable::{HashLookupResult, LispHashTableRef},

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -1,6 +1,7 @@
 //! Basic character set support.
 
 use remacs_macros::lisp_fn;
+use std::ptr;
 
 use crate::{
     hashtable::{HashLookupResult, LispHashTableRef},
@@ -27,7 +28,7 @@ impl LispObject {
 #[lisp_fn]
 pub fn clear_charset_maps() {
     unsafe {
-        *temp_charset_work = Default::default();
+        temp_charset_work = ptr::null_mut();
 
         if Vchar_unify_table.is_char_table() {
             Foptimize_char_table(Vchar_unify_table, Qnil);

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -51,6 +51,7 @@
 #include "termchar.h"
 #include "termhooks.h"
 #include "termopts.h"
+#include "tempcharset.h"
 #include "thread.h"
 #include "tparam.h"
 #include "unexec.h"

--- a/src/charset.c
+++ b/src/charset.c
@@ -39,6 +39,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include "coding.h"
 #include "buffer.h"
 #include "sysstdio.h"
+#include "tempcharset.h"
 
 /*** GENERAL NOTES on CODED CHARACTER SETS (CHARSETS) ***
 
@@ -139,65 +140,6 @@ int iso_charset_table[ISO_MAX_DIMENSION][ISO_MAX_CHARS][ISO_MAX_FINAL];
 	  << 16)							     \
        | (((charset)->code_space[12] + ((idx) / (charset)->code_space[11]))  \
 	  << 24))))
-
-/* Structure to hold mapping tables for a charset.  Used by temacs
-   invoked for dumping.  */
-
-static struct
-{
-  /* The current charset for which the following tables are setup.  */
-  struct charset *current;
-
-  /* 1 iff the following table is used for encoder.  */
-  short for_encoder;
-
-  /* When the following table is used for encoding, minimum and
-     maximum character of the current charset.  */
-  int min_char, max_char;
-
-  /* A Unicode character corresponding to the code index 0 (i.e. the
-     minimum code-point) of the current charset, or -1 if the code
-     index 0 is not a Unicode character.  This is checked when
-     table.encoder[CHAR] is zero.  */
-  int zero_index_char;
-
-  union {
-    /* Table mapping code-indices (not code-points) of the current
-       charset to Unicode characters.  If decoder[CHAR] is -1, CHAR
-       doesn't belong to the current charset.  */
-    int decoder[0x10000];
-    /* Table mapping Unicode characters to code-indices of the current
-       charset.  The first 0x10000 elements are for BMP (0..0xFFFF),
-       and the last 0x10000 are for SMP (0x10000..0x1FFFF) or SIP
-       (0x20000..0x2FFFF).  Note that there is no charset map that
-       uses both SMP and SIP.  */
-    unsigned short encoder[0x20000];
-  } table;
-} *temp_charset_work;
-
-#define SET_TEMP_CHARSET_WORK_ENCODER(C, CODE)			\
-  do {								\
-    if ((CODE) == 0)						\
-      temp_charset_work->zero_index_char = (C);			\
-    else if ((C) < 0x20000)					\
-      temp_charset_work->table.encoder[(C)] = (CODE);		\
-    else							\
-      temp_charset_work->table.encoder[(C) - 0x10000] = (CODE);	\
-  } while (0)
-
-#define GET_TEMP_CHARSET_WORK_ENCODER(C)				  \
-  ((C) == temp_charset_work->zero_index_char ? 0			  \
-   : (C) < 0x20000 ? (temp_charset_work->table.encoder[(C)]		  \
-		      ? (int) temp_charset_work->table.encoder[(C)] : -1) \
-   : temp_charset_work->table.encoder[(C) - 0x10000]			  \
-   ? temp_charset_work->table.encoder[(C) - 0x10000] : -1)
-
-#define SET_TEMP_CHARSET_WORK_DECODER(C, CODE)	\
-  (temp_charset_work->table.decoder[(CODE)] = (C))
-
-#define GET_TEMP_CHARSET_WORK_DECODER(CODE)	\
-  (temp_charset_work->table.decoder[(CODE)])
-
 
 /* Set to 1 to warn that a charset map is loaded and thus a buffer
    text and a string data may be relocated.  */

--- a/src/charset.c
+++ b/src/charset.c
@@ -141,6 +141,8 @@ int iso_charset_table[ISO_MAX_DIMENSION][ISO_MAX_CHARS][ISO_MAX_FINAL];
        | (((charset)->code_space[12] + ((idx) / (charset)->code_space[11]))  \
 	  << 24))))
 
+TempCharsetWork *temp_charset_work;
+
 /* Set to 1 to warn that a charset map is loaded and thus a buffer
    text and a string data may be relocated.  */
 bool charset_map_loaded;

--- a/src/charset.c
+++ b/src/charset.c
@@ -2042,27 +2042,6 @@ DIMENSION, CHARS, and FINAL-CHAR.  */)
   return (id >= 0 ? CHARSET_NAME (CHARSET_FROM_ID (id)) : Qnil);
 }
 
-
-DEFUN ("clear-charset-maps", Fclear_charset_maps, Sclear_charset_maps,
-       0, 0, 0,
-       doc: /*
-Internal use only.
-Clear temporary charset mapping tables.
-It should be called only from temacs invoked for dumping.  */)
-  (void)
-{
-  if (temp_charset_work)
-    {
-      xfree (temp_charset_work);
-      temp_charset_work = NULL;
-    }
-
-  if (CHAR_TABLE_P (Vchar_unify_table))
-    Foptimize_char_table (Vchar_unify_table, Qnil);
-
-  return Qnil;
-}
-
 DEFUN ("charset-priority-list", Fcharset_priority_list,
        Scharset_priority_list, 0, 1, 0,
        doc: /* Return the list of charsets ordered by priority.
@@ -2314,7 +2293,6 @@ syms_of_charset (void)
   defsubr (&Schar_charset);
   defsubr (&Scharset_after);
   defsubr (&Siso_charset);
-  defsubr (&Sclear_charset_maps);
   defsubr (&Scharset_priority_list);
   defsubr (&Sset_charset_priority);
   defsubr (&Scharset_id_internal);

--- a/src/tempcharset.h
+++ b/src/tempcharset.h
@@ -1,0 +1,54 @@
+static struct
+{
+  /* The current charset for which the following tables are setup.  */
+  struct charset *current;
+
+  /* 1 iff the following table is used for encoder.  */
+  short for_encoder;
+
+  /* When the following table is used for encoding, minimum and
+     maximum character of the current charset.  */
+  int min_char, max_char;
+
+  /* A Unicode character corresponding to the code index 0 (i.e. the
+     minimum code-point) of the current charset, or -1 if the code
+     index 0 is not a Unicode character.  This is checked when
+     table.encoder[CHAR] is zero.  */
+  int zero_index_char;
+
+  union {
+    /* Table mapping code-indices (not code-points) of the current
+       charset to Unicode characters.  If decoder[CHAR] is -1, CHAR
+       doesn't belong to the current charset.  */
+    int decoder[0x10000];
+    /* Table mapping Unicode characters to code-indices of the current
+       charset.  The first 0x10000 elements are for BMP (0..0xFFFF),
+       and the last 0x10000 are for SMP (0x10000..0x1FFFF) or SIP
+       (0x20000..0x2FFFF).  Note that there is no charset map that
+       uses both SMP and SIP.  */
+    unsigned short encoder[0x20000];
+  } table;
+} *temp_charset_work;
+
+#define SET_TEMP_CHARSET_WORK_ENCODER(C, CODE)			\
+  do {								\
+    if ((CODE) == 0)						\
+      temp_charset_work->zero_index_char = (C);			\
+    else if ((C) < 0x20000)					\
+      temp_charset_work->table.encoder[(C)] = (CODE);		\
+    else							\
+      temp_charset_work->table.encoder[(C) - 0x10000] = (CODE);	\
+  } while (0)
+
+#define GET_TEMP_CHARSET_WORK_ENCODER(C)				  \
+  ((C) == temp_charset_work->zero_index_char ? 0			  \
+   : (C) < 0x20000 ? (temp_charset_work->table.encoder[(C)]		  \
+		      ? (int) temp_charset_work->table.encoder[(C)] : -1) \
+   : temp_charset_work->table.encoder[(C) - 0x10000]			  \
+   ? temp_charset_work->table.encoder[(C) - 0x10000] : -1)
+
+#define SET_TEMP_CHARSET_WORK_DECODER(C, CODE)	\
+  (temp_charset_work->table.decoder[(CODE)] = (C))
+
+#define GET_TEMP_CHARSET_WORK_DECODER(CODE)	\
+  (temp_charset_work->table.decoder[(CODE)])

--- a/src/tempcharset.h
+++ b/src/tempcharset.h
@@ -30,7 +30,7 @@ typedef struct
   } table;
 } TempCharsetWork;
 
-TempCharsetWork *temp_charset_work;
+extern TempCharsetWork *temp_charset_work;
 
 #define SET_TEMP_CHARSET_WORK_ENCODER(C, CODE)			\
   do {								\

--- a/src/tempcharset.h
+++ b/src/tempcharset.h
@@ -1,4 +1,4 @@
-static struct
+typedef struct
 {
   /* The current charset for which the following tables are setup.  */
   struct charset *current;
@@ -28,7 +28,9 @@ static struct
        uses both SMP and SIP.  */
     unsigned short encoder[0x20000];
   } table;
-} *temp_charset_work;
+} TempCharsetWork;
+
+TempCharsetWork *temp_charset_work;
 
 #define SET_TEMP_CHARSET_WORK_ENCODER(C, CODE)			\
   do {								\


### PR DESCRIPTION
Closes #1174 

I _think_ I'm on the right path here, but I'm not quite there yet. I get this error when running `make`, when trying to link/build the temacs executable:

```
.././rust_src/target/release/libremacs.a(remacs-d72c4967c380b3d7.remacs.254nx1kb-cgu.3.rcgu.o): In function `Fclear_charset_maps':
remacs.254nx1kb-cgu.3:(.text.Fclear_charset_maps+0x4): undefined reference to `temp_charset_work'
```

Part of the reason for this might be that I added a new header file to contain the `temp_charset_work` struct, as I mentioned in issue #1174. I've referenced it in charset.c and wrapper.h, should I add it somewhere else?