### PR TITLE
Port get_frame_param

### DIFF
--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -105,10 +105,10 @@ impl LispFrameRef {
         }
     }
 
-    pub fn get_param(self, prop: LispObject) -> Option<LispObject> {
+    pub fn get_param(self, prop: LispObject) -> LispObject {
         match assq(prop, self.param_alist) {
-            Qnil => None,
-            cons => Some(cdr(cons)),
+            Qnil => Qnil,
+            cons => cdr(cons),
         }
     }
 }
@@ -683,9 +683,9 @@ pub fn frame_face_alist(frame: LispFrameLiveOrSelected) -> LispObject {
 /// Return the value of frame parameter PROP in frame FRAME.
 #[no_mangle]
 pub extern "C" fn get_frame_param(frame: LispFrameRef, prop: LispObject) -> LispObject {
-    // I should be possible to use this method directly when we port
+    // It should be possible to use this method directly when we port
     // one of the original function's callers.
-    frame.get_param(prop).unwrap_or(Qnil)
+    frame.get_param(prop)
 }
 
 include!(concat!(env!("OUT_DIR"), "/frames_exports.rs"));

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -6,7 +6,7 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     lisp::{ExternalPtr, LispObject},
-    lists::{assq, cdr},
+    lists::assq,
     lists::{LispConsCircularChecks, LispConsEndChecks},
     remacs_sys::Vframe_list,
     remacs_sys::{candidate_frame, delete_frame as c_delete_frame, frame_dimension, output_method},
@@ -106,9 +106,9 @@ impl LispFrameRef {
     }
 
     pub fn get_param(self, prop: LispObject) -> LispObject {
-        match assq(prop, self.param_alist) {
-            Qnil => Qnil,
-            cons => cdr(cons),
+        match assq(prop, self.param_alist).as_cons() {
+            Some(cons) => cons.cdr(),
+            None => Qnil,
         }
     }
 }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -105,13 +105,10 @@ impl LispFrameRef {
         }
     }
 
-    pub fn get_param(self, prop: LispObject) -> LispObject {
-        let tem: LispObject = assq(prop, self.param_alist);
-
-        if tem.is_nil() {
-            tem
-        } else {
-            cdr(tem)
+    pub fn get_param(self, prop: LispObject) -> Option<LispObject> {
+        match assq(prop, self.param_alist) {
+            Qnil => None,
+            cons => Some(cdr(cons)),
         }
     }
 }
@@ -688,7 +685,7 @@ pub fn frame_face_alist(frame: LispFrameLiveOrSelected) -> LispObject {
 pub extern "C" fn get_frame_param(frame: LispFrameRef, prop: LispObject) -> LispObject {
     // I should be possible to use this method directly when we port
     // one of the original function's callers.
-    frame.get_param(prop)
+    frame.get_param(prop).unwrap_or(Qnil)
 }
 
 include!(concat!(env!("OUT_DIR"), "/frames_exports.rs"));

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -6,6 +6,7 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     lisp::{ExternalPtr, LispObject},
+    lists::{assq, cdr},
     lists::{LispConsCircularChecks, LispConsEndChecks},
     remacs_sys::Vframe_list,
     remacs_sys::{candidate_frame, delete_frame as c_delete_frame, frame_dimension, output_method},
@@ -101,6 +102,16 @@ impl LispFrameRef {
         #[cfg(not(feature = "window-system"))]
         {
             0
+        }
+    }
+
+    pub fn get_param(self, prop: LispObject) -> LispObject {
+        let tem: LispObject = assq(prop, self.param_alist);
+
+        if tem.is_nil() {
+            tem
+        } else {
+            cdr(tem)
         }
     }
 }
@@ -670,6 +681,11 @@ pub fn visible_frame_list() -> LispObject {
 pub fn frame_face_alist(frame: LispFrameLiveOrSelected) -> LispObject {
     let frame_ref: LispFrameRef = frame.into();
     frame_ref.face_alist
+}
+
+#[no_mangle]
+pub extern "C" fn get_frame_param(frame: LispFrameRef, prop: LispObject) -> LispObject {
+    frame.get_param(prop)
 }
 
 include!(concat!(env!("OUT_DIR"), "/frames_exports.rs"));

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -683,8 +683,11 @@ pub fn frame_face_alist(frame: LispFrameLiveOrSelected) -> LispObject {
     frame_ref.face_alist
 }
 
+/// Return the value of frame parameter PROP in frame FRAME.
 #[no_mangle]
 pub extern "C" fn get_frame_param(frame: LispFrameRef, prop: LispObject) -> LispObject {
+    // I should be possible to use this method directly when we port
+    // one of the original function's callers.
     frame.get_param(prop)
 }
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -148,19 +148,6 @@ check_window_system (struct frame *f)
 	 : "Window system is not in use or not initialized");
 }
 
-/* Return the value of frame parameter PROP in frame FRAME.  */
-
-Lisp_Object
-get_frame_param (register struct frame *frame, Lisp_Object prop)
-{
-  register Lisp_Object tem;
-
-  tem = Fassq (prop, frame->param_alist);
-  if (EQ (tem, Qnil))
-    return tem;
-  return Fcdr (tem);
-}
-
 
 void
 frame_size_history_add (struct frame *f, Lisp_Object fun_symbol,


### PR DESCRIPTION
I noticed this function was fairly simple and only called functions which already had been ported to Rust, so I made an attempt at porting it. 