### PR TITLE
Port file-locked-p

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -73,6 +73,11 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytesize"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +86,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "clippy"
@@ -252,6 +267,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -277,6 +300,27 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "opaque-debug"
@@ -475,6 +519,8 @@ dependencies = [
  "remacs-macros 0.1.0",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "systemstat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,6 +557,14 @@ dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -581,6 +635,33 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "systemstat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytesize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -665,8 +746,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum bytesize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16d794c5fe594cfa8fbe8ae274de4048176c69f2d9ac5e637166e73b71d460b8"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)" = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -690,9 +773,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 "checksum md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
 "checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -713,6 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -722,6 +810,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum systemstat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11374381f619810a32d086459e740a0e4a683f15beea3fe5f3cddb40c8791106"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -30,6 +30,7 @@ md5 = "0.6"
 rand = "0.6.5"
 sha1 = "0.6"
 sha2 = "0.8"
+systemstat = "0.1"
 
 # Only want this local crate as dependency on Mac OS X
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -40,6 +41,9 @@ clippy = { version = "*", optional = true }
 lazy_static = "1.2"
 libc = "0.2"
 regex = "1.1"
+
+[dev-dependencies]
+tempfile = "3.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -38,7 +38,7 @@ use crate::{
     },
     remacs_sys::{
         Fadd_text_properties, Fget_pos_property, Fnext_single_char_property_change,
-        Fprevious_single_char_property_change, Fx_popup_dialog,
+        Fprevious_single_char_property_change, Fsystem_name, Fx_popup_dialog,
     },
     remacs_sys::{
         Qboundary, Qchar_or_string_p, Qfield, Qinteger_or_marker_p, Qmark_inactive, Qnil, Qt,
@@ -1702,6 +1702,11 @@ pub fn insert_before_markers_and_inherit(string: &[u8]) {
             update_compositions(opoint, pt, CHECK_BORDER as i32);
         }
     }
+}
+
+/// Wrapper for Fsystem_name (NOT PORTED)
+pub fn system_name() -> LispStringRef {
+    unsafe { Fsystem_name() }.into()
 }
 
 include!(concat!(env!("OUT_DIR"), "/editfns_exports.rs"));

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -13,12 +13,7 @@ use systemstat::Platform;
 #[cfg(unix)]
 use libc::{ELOOP, O_NOFOLLOW, O_RDONLY};
 #[cfg(unix)]
-use std::{
-    ffi::OsStr,
-    ffi::CString,
-    os::unix::ffi::OsStrExt,
-    os::unix::io::FromRawFd,
-};
+use std::{ffi::CString, ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::io::FromRawFd};
 
 use crate::{
     coding::encode_file_name,
@@ -31,7 +26,6 @@ use crate::{
     threads::ThreadState,
 };
 use LockState::*;
-
 
 /// An arbitrary limit on lock contents length when it is stored in the
 /// contents of the lock file.  8 K should be plenty big enough in practice.

--- a/rust_src/src/filelock.rs
+++ b/rust_src/src/filelock.rs
@@ -2,12 +2,276 @@
 
 use remacs_macros::lisp_fn;
 
+use std::fs::{remove_file, File};
+use std::io::prelude::Read;
+use std::io::Error;
+use std::io::ErrorKind::{InvalidData, InvalidInput, NotFound, PermissionDenied};
+use std::io::Result;
+use std::path::{Path, PathBuf};
+
 use crate::{
+    coding::encode_file_name,
+    editfns::system_name,
+    fileio::expand_file_name,
     lisp::LispObject,
-    remacs_sys::Qstringp,
-    remacs_sys::{lock_file, unlock_file},
+    multibyte::LispStringRef,
+    remacs_sys::{emacs_open, lock_file, maybe_quit, unlock_file},
+    remacs_sys::{Qnil, Qstringp, Qt},
     threads::ThreadState,
 };
+
+/// An arbitrary limit on lock contents length when it is stored in the
+/// contents of the lock file.  8 K should be plenty big enough in practice.
+const MAX_LOCK_INFO: usize = 8 * 1024;
+
+/// The lock info as parsed from a string like `USER@HOST.PID:BOOT_TIME`.
+#[derive(PartialEq, Eq, Debug)]
+struct LockInfo {
+    /// The user that owns the lock.
+    user: String,
+    /// The host on which the file was locked.
+    host: String,
+    /// The ID of the process that locked the file.
+    pid: i32,
+    /// Boot time of the system that locked the file, as Unix epoch seconds.
+    boot_time: Option<i64>,
+}
+
+impl LockInfo {
+    /// Parses a string like `USER@HOST.PID:BOOT_TIME` into a [`LockInfo`].
+    /// Returns [`None`] if the parse fails.
+    fn parse(data: &str) -> Option<LockInfo> {
+        // Treat "\357\200\242" (U+F022 in UTF-8) as if it were ":" (Bug#24656).
+        // This works around a bug in the Linux CIFS kernel client, which can
+        // mistakenly transliterate ':' to U+F022 in symlink contents.
+        // See https://bugzilla.redhat.com/show_bug.cgi?id=1384153
+        let boot_time_sep = |c| c == ':' || c == '\u{F022}';
+
+        // The USER is everything before the last @.
+        let (user, rest) = data.split_at(data.rfind('@')?);
+        let user = user.to_string();
+
+        // The HOST is everything after the '@' to the last '.'.
+        let (at_host, rest) = rest.split_at(rest.rfind('.')?);
+        let host = at_host[1..].to_string();
+
+        // The PID is everything from the last '.' to the ':' or equivalent.
+        // NOTE: Unlike GNU Emacs, we do not tolerate negative PID values
+        // or over/underflow.
+        let (pid_str, boot_time_str) =
+            rest.split_at(rest.find(boot_time_sep).unwrap_or(rest.len()));
+        let pid = pid_str[1..].parse::<i32>().ok().filter(|pid| pid > &0)?;
+
+        // After the ':' or equivalent, if there is one, comes the boot time.
+        let boot_time = if boot_time_str.is_empty() {
+            None
+        } else {
+            // Invalid boot time results in a failed parse of the LockInfo
+            // rather than just boot_time = None.
+            // NOTE: Unlike GNU Emacs, this also applies to over/underflow.
+            // NOTE: Negative value is allowed.
+            Some(
+                boot_time_str
+                    .trim_start_matches(boot_time_sep)
+                    .parse()
+                    .ok()?,
+            )
+        };
+
+        Some(LockInfo {
+            user,
+            host,
+            pid,
+            boot_time,
+        })
+    }
+}
+
+/// The current locking state of a file.
+#[derive(PartialEq, Eq, Debug)]
+enum LockState {
+    /// The file is not locked.
+    NotLocked,
+    /// The file is locked by this Emacs process.
+    LockedByUs,
+    /// The file is locked by some other Emacs process identified
+    /// by [`LockInfo`].
+    LockedBy(LockInfo),
+}
+
+/// Opens a file in `O_NOFOLLOW` mode. Returns [`None`] if the open failed
+/// because the `path` refers to a symbolic link.
+#[cfg(unix)]
+fn open_nofollow(path: &Path) -> Result<Option<File>> {
+    use libc::{ELOOP, O_NOFOLLOW, O_RDONLY};
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::FromRawFd;
+
+    let c_path =
+        CString::new(path.as_os_str().as_bytes()).map_err(|err| Error::new(InvalidInput, err))?;
+    let open_res = unsafe { emacs_open(c_path.as_ptr(), O_RDONLY | O_NOFOLLOW, 0) };
+
+    match open_res {
+        -1 => {
+            let os_error = Error::last_os_error();
+            if os_error.raw_os_error() == Some(ELOOP) {
+                Ok(None)
+            } else {
+                Err(os_error)
+            }
+        }
+
+        fd => {
+            let file = unsafe { File::from_raw_fd(fd) };
+            Ok(Some(file))
+        }
+    }
+}
+
+/// Reads the contents of a regular file at `path` up to `max_content_length` bytes.
+/// Returns [`None`] if the `path` is a symbolic link.
+fn read_nofollow(path: &Path, max_content_length: usize) -> Result<Option<String>> {
+    match open_nofollow(path)? {
+        Some(file) => {
+            let mut content = String::with_capacity(max_content_length);
+            file.take(max_content_length as u64)
+                .read_to_string(&mut content)?;
+            Ok(Some(content))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Reads the target of the symbolic link at `path` and converts it
+/// to a [`String`]. Fails if the target is not valid UTF-8.
+fn read_link_as_string(path: &Path) -> Result<String> {
+    path.read_link()?
+        .into_os_string()
+        .into_string()
+        .map_err(|_| {
+            Error::new(
+                InvalidData,
+                format!("Target of link '{}' is not valid UTF-8", path.display()),
+            )
+        })
+}
+
+/// Reads the info string for the lock file `path`.
+fn read_lock_data(path: &Path) -> Result<String> {
+    loop {
+        match read_link_as_string(path) {
+            ok @ Ok(_) => return ok,
+
+            Err(ref e) if e.kind() == InvalidInput => match read_nofollow(path, MAX_LOCK_INFO)? {
+                Some(target) => return Ok(target),
+                None => (),
+            },
+
+            err => return err,
+        }
+
+        // `read_link` saw a non-symlink, but `open` saw a symlink.
+        // The former must have been removed and replaced by the latter.
+        // Try again.
+        unsafe { maybe_quit() }
+    }
+}
+
+/// Attempts to read and parse the lock information from the lock file `path`.
+/// Returns [`None`] if the lock file does not exist.
+fn read_lock_info(path: &Path) -> Result<Option<LockInfo>> {
+    match read_lock_data(path) {
+        Ok(data) => {
+            let info = LockInfo::parse(&data).ok_or(Error::new(
+                InvalidData,
+                format!("Invalid lock information in '{}'", path.display()),
+            ))?;
+            Ok(Some(info))
+        }
+
+        Err(ref e) if e.kind() == NotFound => Ok(None),
+
+        Err(e) => Err(e),
+    }
+}
+
+/// Returns [`true`] if a process with PID `pid` is running.
+#[cfg(unix)]
+fn process_exists(pid: i32) -> bool {
+    match unsafe { libc::kill(pid, 0) } {
+        0 => true,
+        // `PermissionDenied` indicates that there _is_ a process but it’s
+        // owned by another user
+        _ => Error::last_os_error().kind() == PermissionDenied,
+    }
+}
+
+/// Returns the system’s last boot time as Unix epoch seconds.
+fn get_boot_time() -> Result<i64> {
+    use systemstat::Platform;
+    let sys = systemstat::System::new();
+    sys.boot_time().map(|t| t.timestamp())
+}
+
+/// Returns [`true`] if there is no boot time in the lock info or if the
+/// boot time is within one second of the system’s boot time.
+fn boot_time_within_one_second(info: &LockInfo) -> bool {
+    info.boot_time.map_or(true, |boot_time| {
+        let system_boot_time = get_boot_time().unwrap_or(0);
+        (boot_time - system_boot_time).abs() <= 1
+    })
+}
+
+/// Returns the current state of the lock from lock file `path`.
+fn current_lock_owner(path: &Path) -> Result<LockState> {
+    use LockState::*;
+
+    match read_lock_info(path)? {
+        Some(info) => {
+            // On current host?
+            if info.host.as_bytes() == system_name().as_slice() {
+                if info.pid == std::process::id() as i32 {
+                    // We own it.
+                    Ok(LockedByUs)
+                } else if process_exists(info.pid) && boot_time_within_one_second(&info) {
+                    // An existing process on this machine owns it.
+                    Ok(LockedBy(info))
+                } else {
+                    // The owner process is dead or has a strange pid, so try to
+                    // zap the lockfile.
+                    remove_file(path)?;
+                    Ok(NotLocked)
+                }
+            } else {
+                Ok(LockedBy(info))
+            }
+        }
+
+        None => Ok(NotLocked),
+    }
+}
+
+#[cfg(unix)]
+fn to_path_buf(path: LispStringRef) -> PathBuf {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    let path = encode_file_name(path);
+    PathBuf::from(OsStr::from_bytes(path.as_slice()))
+}
+
+/// Generates a path to a lock file corresponding to the given
+/// file name in `path`.
+fn make_lock_name(path: LispStringRef) -> PathBuf {
+    let mut path = to_path_buf(path);
+
+    let mut lock_file_name = std::ffi::OsString::from(".#");
+    lock_file_name.push(path.file_name().unwrap_or_else(|| std::ffi::OsStr::new("")));
+
+    path.set_file_name(lock_file_name);
+
+    path
+}
 
 /// Lock FILE, if current buffer is modified.
 /// FILE defaults to current buffer's visited file,
@@ -43,4 +307,112 @@ pub fn unlock_buffer_lisp() {
     }
 }
 
+/// Return a value indicating whether FILENAME is locked.
+/// The value is nil if the FILENAME is not locked,
+/// t if it is locked by you, else a string saying which user has locked it.
+#[lisp_fn]
+pub fn file_locked_p(filename: LispStringRef) -> LispObject {
+    use LockState::*;
+
+    let path = make_lock_name(expand_file_name(filename, None));
+
+    match current_lock_owner(&path) {
+        Ok(NotLocked) | Err(_) => Qnil,
+        Ok(LockedByUs) => Qt,
+        Ok(LockedBy(info)) => LispObject::from(info.user.as_str()),
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/filelock_exports.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::remove_file;
+    use tempfile::NamedTempFile;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_link_as_string() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let lock_temp_file = NamedTempFile::new()?;
+        let lock_file = lock_temp_file.path();
+        let target = "test";
+
+        remove_file(lock_file)?;
+        symlink(target, lock_file)?;
+
+        let link = read_link_as_string(lock_file)?;
+        assert_eq!(link, target);
+
+        Ok(())
+    }
+
+    fn example() -> LockInfo {
+        LockInfo {
+            user: "some-user.name".to_string(),
+            host: "test.example.org".to_string(),
+            pid: 123,
+            boot_time: None,
+        }
+    }
+
+    #[test]
+    fn test_parse_lock_info_without_boot_time() {
+        let info = LockInfo::parse("some-user.name@test.example.org.123");
+        let expected = example();
+
+        assert_eq!(info, Some(expected));
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_boot_time() {
+        let info = LockInfo::parse("some-user.name@test.example.org.123:1553441466");
+        let expected = LockInfo {
+            boot_time: Some(1553441466),
+            ..example()
+        };
+
+        assert_eq!(info, Some(expected));
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_cifs_boot_time() {
+        let info = LockInfo::parse("some-user.name@test.example.org.123\u{F022}1553441466");
+        let expected = LockInfo {
+            boot_time: Some(1553441466),
+            ..example()
+        };
+
+        assert_eq!(info, Some(expected));
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_invalid_boot_time() {
+        let info = LockInfo::parse("user@test.123:bogus");
+
+        assert_eq!(info, None);
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_negative_pid() {
+        let info = LockInfo::parse("user@test.-123");
+
+        assert_eq!(info, None);
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_overflow_pid() {
+        let info = LockInfo::parse("user@test.99999999999999999");
+
+        assert_eq!(info, None);
+    }
+
+    #[test]
+    fn test_parse_lock_info_with_overflow_boot_time() {
+        let info = LockInfo::parse("user@test.123:999999999999999999999999999");
+
+        assert_eq!(info, None);
+    }
+}

--- a/src/filelock.c
+++ b/src/filelock.c
@@ -764,34 +764,6 @@ unlock_buffer (struct buffer *buffer)
     unlock_file (BVAR (buffer, file_truename));
 }
 
-DEFUN ("file-locked-p", Ffile_locked_p, Sfile_locked_p, 1, 1, 0,
-       doc: /* Return a value indicating whether FILENAME is locked.
-The value is nil if the FILENAME is not locked,
-t if it is locked by you, else a string saying which user has locked it.  */)
-  (Lisp_Object filename)
-{
-  Lisp_Object ret;
-  char *lfname;
-  int owner;
-  lock_info_type locker;
-  USE_SAFE_ALLOCA;
-
-  filename = Fexpand_file_name (filename, Qnil);
-
-  MAKE_LOCK_NAME (lfname, filename);
-
-  owner = current_lock_owner (&locker, lfname);
-  if (owner <= 0)
-    ret = Qnil;
-  else if (owner == 2)
-    ret = Qt;
-  else
-    ret = make_string (locker.user, locker.at - locker.user);
-
-  SAFE_FREE ();
-  return ret;
-}
-
 void
 syms_of_filelock (void)
 {
@@ -802,6 +774,4 @@ syms_of_filelock (void)
   DEFVAR_BOOL ("create-lockfiles", create_lockfiles,
 	       doc: /* Non-nil means use lockfiles to avoid editing collisions.  */);
   create_lockfiles = 1;
-
-  defsubr (&Sfile_locked_p);
 }

--- a/test/rust_src/src/filelock-tests.el
+++ b/test/rust_src/src/filelock-tests.el
@@ -5,7 +5,7 @@
 (require 'ert)
 
 (ert-deftest filelock-tests--lock-buffer-base ()
-  "Check lock-buffer base cases"
+  "Check lock-buffer base cases."
   (should (eq nil (lock-buffer)))
   (should (eq nil (lock-buffer nil)))
   (should-error (eval '(lock-buffer "foo" "bar")) :type 'wrong-number-of-arguments)
@@ -15,26 +15,26 @@
   (should-error (eval '(lock-buffer t)) :type 'wrong-type-argument))
 
 (ert-deftest filelock-tests--unlock-buffer-base ()
-  "Check unlock-buffer base cases"
+  "Check unlock-buffer base cases."
   (should (eq nil (unlock-buffer)))
   (should-error (eval '(unlock-buffer "foo")) :type 'wrong-number-of-arguments)
   (should-error (eval '(unlock-buffer nil)) :type 'wrong-number-of-arguments))
 
 (ert-deftest filelock-tests--lock-buffer-current ()
-  "Check locking of current buffer"
+  "Check locking of current buffer."
   (let ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test")))
     (unwind-protect
         (progn
           (find-file-existing file)
           (insert "modification")
           (lock-buffer)
-          (should (eq t (file-locked-p file)))
+          (should (file-locked-p file))
           (unlock-buffer)
-          (should (eq nil (file-locked-p file))))
+          (should-not (file-locked-p file)))
       (delete-file file nil))))
 
 (ert-deftest filelock-tests--lock-buffer-other ()
-  "Check locking of other file"
+  "Check locking of a file that is not the current buffer’s file."
   (let ((file (make-temp-file "filelock-tests--other-" nil ".txt" "test"))
         (other (make-temp-file "filelock-tests--other-to-lock-" nil ".txt" "to-lock")))
     (unwind-protect
@@ -43,17 +43,32 @@
           (insert "modification")
           (lock-buffer other)
           ; I don’t understand this but it replicates GNU Emacs behavior
-          (should (eq t (file-locked-p file)))
-          (should (eq t (file-locked-p other)))
+          (should (file-locked-p file))
+          (should (file-locked-p other))
           (unlock-buffer)
-          (should (eq nil (file-locked-p file)))
-          (should (eq t (file-locked-p other))))
+          (should-not (file-locked-p file))
+          (should (file-locked-p other)))
       (find-file-existing other)
       (unlock-buffer)
       (delete-file file nil)
       (delete-file other nil))))
 
+(ert-deftest filelock-tests--unlock-buffer-deletes ()
+  "Check that unlock-buffer deletes the lock file."
+  (let* ((file (make-temp-file "filelock-tests--unlock-buffer-deletes-" nil ".txt" "test"))
+         (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
+    (unwind-protect
+        (progn
+          (find-file-existing file)
+          (insert "modification")
+          (lock-buffer)
+          (should (or (file-symlink-p lock-file) (file-exists-p lock-file)))
+          (unlock-buffer)
+          (should-not (and (file-symlink-p lock-file) (file-exists-p lock-file))))
+      (delete-file file nil))))
+
 (ert-deftest filelock-tests--file-locked-p-base ()
+  "Check file-locked-p base cases."
   (should-error (file-locked-p))
   (should-error (file-locked-p "foo" "bar"))
   (should-error (file-locked-p '("foo")))
@@ -62,36 +77,42 @@
   (should-error (file-locked-p 'bogus))
   (should-error (file-locked-p 1))
 
-  (should (eq nil (file-locked-p "/this/file/should/not/exist")))
-  (should (eq nil (file-locked-p "~/this/file/should/not/exist"))))
+  (should-not (file-locked-p "/this/file/should/not/exist"))
+  (should-not (file-locked-p "~/this/file/should/not/exist")))
 
 (ert-deftest filelock-tests--file-locked-p-unicode ()
-  (let ((file (make-temp-file "filelock-tests--encoding-🤔-" nil ".txt" "test")))
+  "Check that file locking works with files containing unicode characters."
+  (let ((file (make-temp-file "filelock-tests--unicode-🤔-" nil ".txt" "test")))
     (unwind-protect
         (progn
           (find-file-existing file)
           (insert "modification")
           (lock-buffer)
-          (should (eq t (file-locked-p file))))
+          (should (file-locked-p file)))
+      (unlock-buffer)
       (delete-file file nil))))
 
 (ert-deftest filelock-tests--file-locked-p-file-name-coding ()
+  "Check that file-locked-p respects encoding (#35171)."
+  ; w32-unicode-filenames overrides file-name-coding-system on (modern) Windows
+  ; so no need to test this in that case.
   (unless (eq system-type 'windows-nt)
     (let ((file-name-coding-system 'latin-1-unix)
-          (file (make-temp-file "filelock-tests--encoding-bug-éö-" nil ".txt" "test")))
+          (file (make-temp-file "filelock-tests--encoding-éö-" nil ".txt" "test")))
       (unwind-protect
           (progn
             (find-file-existing file)
             (insert "modification")
             (lock-buffer)
-            (should (eq t (file-locked-p file))))
+            (should (file-locked-p file)))
+        (unlock-buffer)
         (delete-file file nil)))))
 
 (ert-deftest filelock-tests--locked-by-other-user ()
   "Check file-locked-p for (non-symlink) lock owned by some other user."
   (let* ((key (random most-positive-fixnum))
          (user (format "some-%d-user" key))
-         (file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+         (file (make-temp-file "filelock-tests--locked-by-other-user-" nil ".txt" "test"))
          (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
     (unwind-protect
         (progn
@@ -103,20 +124,20 @@
 
 (ert-deftest filelock-tests--locked-by-us ()
   "Check file-locked-p for (non-symlink) lock owned by current user."
-  (let* ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+  (let* ((file (make-temp-file "filelock-tests--locked-by-us-" nil ".txt" "test"))
          (user (user-login-name))
          (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
     (unwind-protect
         (progn
           (with-temp-file lock-file
             (insert (format "%s@%s.%d" user (system-name) (emacs-pid))))
-          (should (eq t (file-locked-p file)))))
+          (should (file-locked-p file))))
     (delete-file file nil)
     (delete-file lock-file nil)))
 
 (ert-deftest filelock-tests--locked-by-other-process ()
   "Check file-locked-p for (non-symlink) lock owned by another current user’s process."
-  (let* ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+  (let* ((file (make-temp-file "filelock-tests--locked-by-other-process-" nil ".txt" "test"))
          (user (user-login-name))
          ; PID 1 on *nix and 4 on Windows should always exist?
          (pid (if (eq system-type 'windows-nt) 4 1))

--- a/test/rust_src/src/filelock-tests.el
+++ b/test/rust_src/src/filelock-tests.el
@@ -23,24 +23,108 @@
 (ert-deftest filelock-tests--lock-buffer-current ()
   "Check locking of current buffer"
   (let ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test")))
-    (find-file-existing file)
-    (insert "modification")
-    (lock-buffer)
-    (should (eq t (file-locked-p file)))
-    (unlock-buffer)
-    (should (eq nil (file-locked-p file)))))
+    (unwind-protect
+        (progn
+          (find-file-existing file)
+          (insert "modification")
+          (lock-buffer)
+          (should (eq t (file-locked-p file)))
+          (unlock-buffer)
+          (should (eq nil (file-locked-p file))))
+      (delete-file file nil))))
 
 (ert-deftest filelock-tests--lock-buffer-other ()
   "Check locking of other file"
   (let ((file (make-temp-file "filelock-tests--other-" nil ".txt" "test"))
         (other (make-temp-file "filelock-tests--other-to-lock-" nil ".txt" "to-lock")))
-    (find-file-existing file)
-    (insert "modification")
-    (lock-buffer other)
-    ; I don’t understand this but it replicates GNU Emacs behavior
-    (should (eq t (file-locked-p file)))
-    (should (eq t (file-locked-p other)))
-    (unlock-buffer)
-    (should (eq nil (file-locked-p file)))
-    (should (eq t (file-locked-p other)))))
+    (unwind-protect
+        (progn
+          (find-file-existing file)
+          (insert "modification")
+          (lock-buffer other)
+          ; I don’t understand this but it replicates GNU Emacs behavior
+          (should (eq t (file-locked-p file)))
+          (should (eq t (file-locked-p other)))
+          (unlock-buffer)
+          (should (eq nil (file-locked-p file)))
+          (should (eq t (file-locked-p other))))
+      (find-file-existing other)
+      (unlock-buffer)
+      (delete-file file nil)
+      (delete-file other nil))))
 
+(ert-deftest filelock-tests--file-locked-p-base ()
+  (should-error (file-locked-p))
+  (should-error (file-locked-p "foo" "bar"))
+  (should-error (file-locked-p '("foo")))
+  (should-error (file-locked-p nil))
+  (should-error (file-locked-p t))
+  (should-error (file-locked-p 'bogus))
+  (should-error (file-locked-p 1))
+
+  (should (eq nil (file-locked-p "/this/file/should/not/exist")))
+  (should (eq nil (file-locked-p "~/this/file/should/not/exist"))))
+
+(ert-deftest filelock-tests--file-locked-p-unicode ()
+  (let ((file (make-temp-file "filelock-tests--encoding-🤔-" nil ".txt" "test")))
+    (unwind-protect
+        (progn
+          (find-file-existing file)
+          (insert "modification")
+          (lock-buffer)
+          (should (eq t (file-locked-p file))))
+      (delete-file file nil))))
+
+(ert-deftest filelock-tests--file-locked-p-file-name-coding ()
+  (unless (eq system-type 'windows-nt)
+    (let ((file-name-coding-system 'latin-1-unix)
+          (file (make-temp-file "filelock-tests--encoding-bug-éö-" nil ".txt" "test")))
+      (unwind-protect
+          (progn
+            (find-file-existing file)
+            (insert "modification")
+            (lock-buffer)
+            (should (eq t (file-locked-p file))))
+        (delete-file file nil)))))
+
+(ert-deftest filelock-tests--locked-by-other-user ()
+  "Check file-locked-p for (non-symlink) lock owned by some other user."
+  (let* ((key (random most-positive-fixnum))
+         (user (format "some-%d-user" key))
+         (file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+         (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
+    (unwind-protect
+        (progn
+          (with-temp-file lock-file
+            (insert (format "%s@some-%d-host.123" user key)))
+          (should (equal user (file-locked-p file))))
+      (delete-file file nil)
+      (delete-file lock-file nil))))
+
+(ert-deftest filelock-tests--locked-by-us ()
+  "Check file-locked-p for (non-symlink) lock owned by current user."
+  (let* ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+         (user (user-login-name))
+         (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
+    (unwind-protect
+        (progn
+          (with-temp-file lock-file
+            (insert (format "%s@%s.%d" user (system-name) (emacs-pid))))
+          (should (eq t (file-locked-p file)))))
+    (delete-file file nil)
+    (delete-file lock-file nil)))
+
+(ert-deftest filelock-tests--locked-by-other-process ()
+  "Check file-locked-p for (non-symlink) lock owned by another current user’s process."
+  (let* ((file (make-temp-file "filelock-tests--current-" nil ".txt" "test"))
+         (user (user-login-name))
+         ; PID 1 on *nix and 4 on Windows should always exist?
+         (pid (if (eq system-type 'windows-nt) 4 1))
+         (lock-file (concat (file-name-directory file) (concat ".#" (file-name-nondirectory file)))))
+    (unwind-protect
+        (progn
+          (with-temp-file lock-file
+            (insert (format "%s@%s.%d" user (system-name) pid)))
+          (should (equal user (file-locked-p file))))
+      (delete-file file nil)
+      (delete-file lock-file nil))))


### PR DESCRIPTION
As a sort of continuation to #1394.

Some notes/caveats:
 - No Windows support. remacs doesn’t seem to build on Windows right now so there’s no way to test :frowning_face: 
 - Adds dependency to [systemstat crate](https://crates.io/crates/systemstat), which provides, among other things, system boot time information.
 - Some duplication between `filelock.c` and `filelock.rs` remain, pending ports of [`lock_file`](https://github.com/remacs/remacs/blob/fa68c1f5df7834d063e8b9c7b8a262178e0059ca/src/filelock.c#L640), [`unlock_file`](https://github.com/remacs/remacs/blob/fa68c1f5df7834d063e8b9c7b8a262178e0059ca/src/filelock.c#L725), [`unlock_all_files`](https://github.com/remacs/remacs/blob/fa68c1f5df7834d063e8b9c7b8a262178e0059ca/src/filelock.c#L742) and [`unlock_buffer`](https://github.com/remacs/remacs/blob/fa68c1f5df7834d063e8b9c7b8a262178e0059ca/src/filelock.c#L757).
