### PR TITLE
Port font-get-system-font and font-get-system-normal-font

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -126,6 +126,7 @@ mod windows;
 mod xdisp;
 mod xfaces;
 mod xml;
+mod xsettings;
 
 #[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -126,6 +126,7 @@ mod windows;
 mod xdisp;
 mod xfaces;
 mod xml;
+#[cfg(feature = "window-system-x11")]
 mod xsettings;
 
 #[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]

--- a/rust_src/src/xsettings.rs
+++ b/rust_src/src/xsettings.rs
@@ -3,13 +3,16 @@
 use remacs_macros::lisp_fn;
 
 use crate::{
-    lisp::LispObject, remacs_sys::build_string, remacs_sys::current_mono_font, remacs_sys::Qnil,
+    lisp::LispObject,
+    remacs_sys::build_string,
+    remacs_sys::Qnil,
+    remacs_sys::{current_font, current_mono_font},
 };
 
 /// Get the system default application font.
 #[lisp_fn]
 pub fn font_get_system_normal_font() -> LispObject {
-    if unsafe { current_font.is_nul() } {
+    if unsafe { current_font.is_null() } {
         Qnil
     } else {
         unsafe { build_string(current_font) }

--- a/rust_src/src/xsettings.rs
+++ b/rust_src/src/xsettings.rs
@@ -1,4 +1,9 @@
 //! Functions for handling font and other changes dynamically.
+//!
+//! All of the functions defined in this file and on xsettings.c are
+//! only defined when Remacs is compiled with support for the X window
+//! system.
+
 #[cfg(feature = "window-system-x11")]
 use remacs_macros::lisp_fn;
 

--- a/rust_src/src/xsettings.rs
+++ b/rust_src/src/xsettings.rs
@@ -3,11 +3,8 @@
 //! All of the functions defined in this file and on xsettings.c are
 //! only defined when Remacs is compiled with support for the X window
 //! system.
-
-#[cfg(feature = "window-system-x11")]
 use remacs_macros::lisp_fn;
 
-#[cfg(feature = "window-system-x11")]
 use crate::{
     lisp::LispObject,
     remacs_sys::build_string,
@@ -16,7 +13,6 @@ use crate::{
 };
 
 /// Get the system default application font.
-#[cfg(feature = "window-system-x11")]
 #[lisp_fn]
 pub fn font_get_system_normal_font() -> LispObject {
     if unsafe { current_font.is_null() } {
@@ -27,7 +23,6 @@ pub fn font_get_system_normal_font() -> LispObject {
 }
 
 /// Get the system default fixed width font.
-#[cfg(feature = "window-system-x11")]
 #[lisp_fn]
 pub fn font_get_system_font() -> LispObject {
     if unsafe { current_mono_font.is_null() } {

--- a/rust_src/src/xsettings.rs
+++ b/rust_src/src/xsettings.rs
@@ -1,7 +1,8 @@
 //! Functions for handling font and other changes dynamically.
-
+#[cfg(feature = "window-system-x11")]
 use remacs_macros::lisp_fn;
 
+#[cfg(feature = "window-system-x11")]
 use crate::{
     lisp::LispObject,
     remacs_sys::build_string,
@@ -10,6 +11,7 @@ use crate::{
 };
 
 /// Get the system default application font.
+#[cfg(feature = "window-system-x11")]
 #[lisp_fn]
 pub fn font_get_system_normal_font() -> LispObject {
     if unsafe { current_font.is_null() } {
@@ -20,6 +22,7 @@ pub fn font_get_system_normal_font() -> LispObject {
 }
 
 /// Get the system default fixed width font.
+#[cfg(feature = "window-system-x11")]
 #[lisp_fn]
 pub fn font_get_system_font() -> LispObject {
     if unsafe { current_mono_font.is_null() } {

--- a/rust_src/src/xsettings.rs
+++ b/rust_src/src/xsettings.rs
@@ -1,0 +1,29 @@
+//! Functions for handling font and other changes dynamically.
+
+use remacs_macros::lisp_fn;
+
+use crate::{
+    lisp::LispObject, remacs_sys::build_string, remacs_sys::current_mono_font, remacs_sys::Qnil,
+};
+
+/// Get the system default application font.
+#[lisp_fn]
+pub fn font_get_system_normal_font() -> LispObject {
+    if unsafe { current_font.is_nul() } {
+        Qnil
+    } else {
+        unsafe { build_string(current_font) }
+    }
+}
+
+/// Get the system default fixed width font.
+#[lisp_fn]
+pub fn font_get_system_font() -> LispObject {
+    if unsafe { current_mono_font.is_null() } {
+        Qnil
+    } else {
+        unsafe { build_string(current_mono_font) }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/xsettings_exports.rs"));

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -52,6 +52,7 @@
 #include "termhooks.h"
 #include "termopts.h"
 #include "tempcharset.h"
+#include "tempxsettings.h"
 #include "thread.h"
 #include "tparam.h"
 #include "unexec.h"

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -52,7 +52,6 @@
 #include "termhooks.h"
 #include "termopts.h"
 #include "tempcharset.h"
-#include "tempxsettings.h"
 #include "thread.h"
 #include "tparam.h"
 #include "unexec.h"
@@ -60,6 +59,7 @@
 # include "widget.h"
 # include "widgetprv.h"
 # include "xsettings.h"
+# include "tempxsettings.h"
 #endif
 #include "window.h"
 #include "xgselect.h"

--- a/src/tempxsettings.h
+++ b/src/tempxsettings.h
@@ -1,3 +1,7 @@
+/* This file contains declarations for elements of xsettings.c that
+   were originally static and thus private to that file. Its goal is
+   to make these elements (variables functions) acessible when as we
+   port xsettings.c to Rust. */
+
 extern char *current_mono_font;
 extern char *current_font;
-extern struct x_display_info *first_dpyinfo;

--- a/src/tempxsettings.h
+++ b/src/tempxsettings.h
@@ -1,0 +1,3 @@
+extern char *current_mono_font;
+extern char *current_font;
+extern struct x_display_info *first_dpyinfo;

--- a/src/xsettings.c
+++ b/src/xsettings.c
@@ -32,6 +32,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include "keyboard.h"
 #include "blockinput.h"
 #include "termhooks.h"
+#include "tempxsettings.h"
 
 #include <X11/Xproto.h>
 
@@ -48,7 +49,9 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <X11/Xft/Xft.h>
 #endif
 
-#include "tempxsettings.h"
+char *current_mono_font;
+char *current_font;
+struct x_display_info *first_dpyinfo;
 static Lisp_Object current_tool_bar_style;
 
 /* Store a config changed event in to the event queue.  */
@@ -971,23 +974,6 @@ xsettings_get_system_font (void)
   return current_mono_font;
 }
 
-DEFUN ("font-get-system-normal-font", Ffont_get_system_normal_font,
-       Sfont_get_system_normal_font,
-       0, 0, 0,
-       doc: /* Get the system default application font. */)
-  (void)
-{
-  return current_font ? build_string (current_font) : Qnil;
-}
-
-DEFUN ("font-get-system-font", Ffont_get_system_font, Sfont_get_system_font,
-       0, 0, 0,
-       doc: /* Get the system default fixed width font. */)
-  (void)
-{
-  return current_mono_font ? build_string (current_mono_font) : Qnil;
-}
-
 DEFUN ("tool-bar-get-system-style", Ftool_bar_get_system_style,
        Stool_bar_get_system_style, 0, 0, 0,
        doc: /* Get the system tool bar style.
@@ -1022,8 +1008,6 @@ syms_of_xsettings (void)
   DEFSYM (Qmonospace_font_name, "monospace-font-name");
   DEFSYM (Qfont_name, "font-name");
   DEFSYM (Qfont_render, "font-render");
-  defsubr (&Sfont_get_system_font);
-  defsubr (&Sfont_get_system_normal_font);
 
   DEFVAR_BOOL ("font-use-system-font", use_system_font,
     doc: /* Non-nil means to apply the system defined font dynamically.

--- a/src/xsettings.c
+++ b/src/xsettings.c
@@ -48,9 +48,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <X11/Xft/Xft.h>
 #endif
 
-static char *current_mono_font;
-static char *current_font;
-static struct x_display_info *first_dpyinfo;
+#include "tempxsettings.h"
 static Lisp_Object current_tool_bar_style;
 
 /* Store a config changed event in to the event queue.  */

--- a/src/xsettings.c
+++ b/src/xsettings.c
@@ -51,7 +51,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 
 char *current_mono_font;
 char *current_font;
-struct x_display_info *first_dpyinfo;
+static struct x_display_info *first_dpyinfo;
 static Lisp_Object current_tool_bar_style;
 
 /* Store a config changed event in to the event queue.  */


### PR DESCRIPTION
There wasn't a xsettings.rs file yet, so I created it. Since both of these functions relied on static C variables, I went with the same strategy I used for clear-charset-maps, creating a new `tempxsettings.h` header to contain their `extern` declarations.

This closes #1458 and also ports font-get-normal-system-font, which was very similar.