### PR TITLE
Make Codepoint a newtype

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -10,7 +10,7 @@ use crate::{
     base64_crate,
     buffers::validate_region_rust,
     lisp::LispObject,
-    multibyte::{multibyte_char_at, raw_byte_from_codepoint, LispStringRef, MAX_5_BYTE_CHAR},
+    multibyte::{multibyte_char_at, LispStringRef},
     remacs_sys::EmacsInt,
     remacs_sys::{
         del_range_both, del_range_byte, insert, insert_1_both, make_unibyte_string, move_gap_both,
@@ -29,10 +29,10 @@ fn base64_encode_1(bytes: &[u8], line_break: bool, multibyte: bool) -> Result<St
         let mut i = 0;
         while i < bytes.len() {
             let (cp, len) = multibyte_char_at(&bytes[i..]);
-            if cp > MAX_5_BYTE_CHAR {
-                input.push(raw_byte_from_codepoint(cp));
-            } else if cp < 256 {
-                input.push(cp as c_uchar);
+            if cp.is_byte8() {
+                input.push(cp.to_byte8_unchecked());
+            } else if cp.is_single_byte() {
+                input.push(cp.val() as c_uchar);
             } else {
                 return Err(());
             }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -366,13 +366,13 @@ impl LispBufferRef {
             0
         };
 
-        unsafe {
-            let (c, _) = multibyte_char_at(slice::from_raw_parts(
+        let (c, _) = multibyte_char_at(unsafe {
+            slice::from_raw_parts(
                 self.beg_addr().offset(offset + n - self.beg_byte()),
                 MAX_MULTIBYTE_LENGTH,
-            ));
-            c
-        }
+            )
+        });
+        c
     }
 
     pub fn multibyte_characters_enabled(self) -> bool {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1,9 +1,9 @@
 //! Functions operating on buffers.
 
-use std::{self, iter, mem, ops, ptr};
+use std::{self, iter, mem, ops, ptr, slice};
 
 use field_offset::FieldOffset;
-use libc::{self, c_char, c_int, c_uchar, c_void, ptrdiff_t};
+use libc::{self, c_char, c_uchar, c_void, ptrdiff_t};
 
 use rand::{thread_rng, Rng};
 
@@ -28,8 +28,9 @@ use crate::{
         build_marker, build_marker_rust, marker_buffer, marker_position_lisp, set_marker_both,
         LispMarkerRef, MARKER_DEBUG,
     },
-    multibyte::{multibyte_chars_in_text, multibyte_length_by_head, string_char},
-    multibyte::{LispStringRef, LispSymbolOrString},
+    multibyte::MAX_MULTIBYTE_LENGTH,
+    multibyte::{multibyte_char_at, multibyte_chars_in_text, multibyte_length_by_head},
+    multibyte::{Codepoint, LispStringRef, LispSymbolOrString},
     numbers::{LispNumber, MOST_POSITIVE_FIXNUM},
     obarray::intern,
     remacs_sys::symbol_trapped_write::SYMBOL_TRAPPED_WRITE,
@@ -347,18 +348,18 @@ impl LispBufferRef {
 
     /// Return character at byte position POS.  See the caveat WARNING for
     /// FETCH_MULTIBYTE_CHAR below.
-    pub fn fetch_char(self, n: ptrdiff_t) -> c_int {
+    pub fn fetch_char(self, n: ptrdiff_t) -> Codepoint {
         if self.multibyte_characters_enabled() {
             self.fetch_multibyte_char(n)
         } else {
-            c_int::from(self.fetch_byte(n))
+            Codepoint::from(self.fetch_byte(n))
         }
     }
 
     /// Return character code of multi-byte form at byte position POS.  If POS
     /// doesn't point the head of valid multi-byte form, only the byte at
     /// POS is returned.  No range checking.
-    pub fn fetch_multibyte_char(self, n: ptrdiff_t) -> c_int {
+    pub fn fetch_multibyte_char(self, n: ptrdiff_t) -> Codepoint {
         let offset = if n >= self.gpt_byte() && n >= 0 {
             self.gap_size()
         } else {
@@ -366,11 +367,11 @@ impl LispBufferRef {
         };
 
         unsafe {
-            string_char(
+            let (c, _) = multibyte_char_at(slice::from_raw_parts(
                 self.beg_addr().offset(offset + n - self.beg_byte()),
-                ptr::null_mut(),
-                ptr::null_mut(),
-            )
+                MAX_MULTIBYTE_LENGTH,
+            ));
+            c
         }
     }
 

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -17,12 +17,6 @@ impl LispObject {
         self.as_fixnum()
             .map_or(false, |i| 0 <= i && i <= EmacsInt::from(MAX_CHAR))
     }
-
-    /// Check if Lisp object is a character or not and return the codepoint
-    /// Similar to CHECK_CHARACTER
-    pub fn as_character_or_error(self) -> Codepoint {
-        Codepoint::from(self)
-    }
 }
 
 /// True iff byte starts a character in a multibyte form.

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -8,7 +8,6 @@ use crate::{
     lisp::LispObject,
     multibyte::{Codepoint, MAX_CHAR},
     remacs_sys::EmacsInt,
-    remacs_sys::Qcharacterp,
     threads::ThreadState,
 };
 
@@ -22,10 +21,7 @@ impl LispObject {
     /// Check if Lisp object is a character or not and return the codepoint
     /// Similar to CHECK_CHARACTER
     pub fn as_character_or_error(self) -> Codepoint {
-        if !self.is_character() {
-            wrong_type!(Qcharacterp, self)
-        }
-        Codepoint::from(self.as_fixnum().unwrap() as u32)
+        Codepoint::from(self)
     }
 }
 

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -6,7 +6,6 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     lisp::LispObject,
-    multibyte::{make_char_multibyte, raw_byte_from_codepoint_safe},
     multibyte::{Codepoint, MAX_CHAR},
     remacs_sys::EmacsInt,
     remacs_sys::Qcharacterp,
@@ -26,7 +25,7 @@ impl LispObject {
         if !self.is_character() {
             wrong_type!(Qcharacterp, self)
         }
-        self.as_fixnum().unwrap() as Codepoint
+        Codepoint::from(self.as_fixnum().unwrap() as u32)
     }
 }
 
@@ -61,7 +60,7 @@ pub unsafe fn dec_pos(pos_byte: ptrdiff_t) -> ptrdiff_t {
 
 /// Return the character of the maximum code.
 #[lisp_fn]
-pub fn max_char() -> LispObject {
+pub fn max_char() -> Codepoint {
     MAX_CHAR.into()
 }
 
@@ -83,25 +82,23 @@ pub fn char_or_string_p(object: LispObject) -> bool {
 
 /// Convert the byte CH to multibyte character.
 #[lisp_fn]
-pub fn unibyte_char_to_multibyte(ch: LispObject) -> LispObject {
-    let c = ch.as_character_or_error();
-    if c >= 0x100 {
-        error!("Not a unibyte character: {}", c);
+pub fn unibyte_char_to_multibyte(ch: Codepoint) -> Codepoint {
+    if !ch.is_single_byte() {
+        error!("Not a unibyte character: {}", ch);
     }
-    make_char_multibyte(c).into()
+    ch.to_multibyte()
 }
 
 /// Convert the multibyte character CH to a byte.
 /// If the multibyte character does not represent a byte, return -1.
 #[lisp_fn]
-pub fn multibyte_char_to_unibyte(ch: LispObject) -> LispObject {
-    let c = ch.as_character_or_error();
-    if c < 256 {
+pub fn multibyte_char_to_unibyte(ch: Codepoint) -> EmacsInt {
+    if ch.is_single_byte() {
         // Can't distinguish a byte read from a unibyte buffer from
         // a latin1 char, so let's let it slide.
-        ch
+        ch.into()
     } else {
-        raw_byte_from_codepoint_safe(c).into()
+        ch.to_byte8().map(EmacsInt::from).unwrap_or(-1)
     }
 }
 

--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -142,14 +142,14 @@ pub fn end_of_line(n: Option<EmacsInt>) {
         newpos = line_end_position(Some(num)) as isize;
         unsafe { set_point(newpos) };
         pt = cur_buf.pt;
-        if pt > newpos && cur_buf.fetch_char(pt - 1) == '\n' as i32 {
+        if pt > newpos && cur_buf.fetch_char(pt - 1) == '\n' {
             // If we skipped over a newline that follows
             // an invisible intangible run,
             // move back to the last tangible position
             // within the line.
             unsafe { set_point(pt - 1) };
             break;
-        } else if pt > newpos && pt < cur_buf.zv && cur_buf.fetch_char(newpos) != '\n' as i32 {
+        } else if pt > newpos && pt < cur_buf.zv && cur_buf.fetch_char(newpos) != '\n' {
             // If we skipped something intangible
             // and now we're not really at eol,
             // keep going.
@@ -266,8 +266,8 @@ pub fn self_insert_command(n: EmacsInt) {
                 globals.Vtranslation_table_for_input,
                 globals.last_command_event.as_fixnum_or_error() as i32,
             )
-        };
-        let val = internal_self_insert(Codepoint::from(character as u32), n as usize);
+        } as u32;
+        let val = internal_self_insert(character.into(), n as usize);
         if val == 2 {
             set(Qundo_auto__this_command_amalgamating.into(), Qnil);
         }
@@ -329,7 +329,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         // C2 and several characters following C2.
 
         // This is the character after point.
-        let c2 = Codepoint::from(current_buffer.fetch_char(current_buffer.pt_byte) as u32);
+        let c2 = current_buffer.fetch_char(current_buffer.pt_byte);
 
         // Overwriting in binary-mode always replaces C2 by C.
         // Overwriting in textual-mode doesn't always do that.
@@ -362,9 +362,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
                         // We will delete too many columns.  Let's fill columns
                         // by spaces so that the remaining text won't move.
                         let actual = unsafe { character::dec_pos(current_buffer.pt_byte) };
-                        if Codepoint::from(current_buffer.fetch_char(actual) as u32)
-                            == Codepoint::from('\t')
-                        {
+                        if current_buffer.fetch_char(actual) == '\t' {
                             // Rather than add spaces, let's just keep the tab.
                             chars_to_delete -= 1;
                         } else {
@@ -451,10 +449,10 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
 
     if let Some(t) = unsafe { globals.Vauto_fill_chars }.as_char_table() {
         if t.get(c.val() as isize).is_not_nil()
-            && (c == Codepoint::from(' ') || c == Codepoint::from('\n'))
+            && (c == ' ' || c == '\n')
             && current_buffer.auto_fill_function_.is_not_nil()
         {
-            if c == Codepoint::from('\n') {
+            if c == '\n' {
                 // After inserting a newline, move to previous line and fill
                 // that.  Must have the newline in place already so filling and
                 // justification, if any, know where the end is going to be.
@@ -464,7 +462,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
             }
             let auto_fill_result = call!(Qinternal_auto_fill);
             // Test PT < ZV in case the auto-fill-function is strange.
-            if c == Codepoint::from('\n') && current_buffer.pt < current_buffer.zv {
+            if c == '\n' && current_buffer.pt < current_buffer.zv {
                 let newpt = current_buffer.pt + 1;
                 let newpt_byte = current_buffer.pt_byte + 1;
                 current_buffer.set_pt_both(newpt, newpt_byte);

--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -338,7 +338,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         // or before a tab if it doesn't use the whole width of the tab.  */
         if overwrite == Qoverwrite_mode_binary {
             chars_to_delete = n as usize;
-        } else if c != Codepoint::from('\n') && c2 != Codepoint::from('\n') {
+        } else if c != '\n' && c2 != '\n' {
             let cwidth = unsafe { Fchar_width(c.into()) }.as_fixnum_or_error() as usize;
             if cwidth > 0 {
                 let pos = current_buffer.pt;
@@ -417,8 +417,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         };
         let mut string = unsafe { Fmake_string(n.into(), mc.into(), Qnil) };
         if spaces_to_insert > 0 {
-            let tem =
-                unsafe { Fmake_string(spaces_to_insert.into(), Codepoint::from(' ').into(), Qnil) };
+            let tem = unsafe { Fmake_string(spaces_to_insert.into(), b' '.into(), Qnil) };
             string = unsafe { concat2(string, tem) };
         }
 

--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -15,10 +15,7 @@ use crate::{
     keymap::{current_global_map, Ctl},
     lisp::LispObject,
     lists::get,
-    multibyte::{
-        char_to_byte8, single_byte_charp, unibyte_to_char, write_codepoint, Codepoint,
-        MAX_MULTIBYTE_LENGTH,
-    },
+    multibyte::{Codepoint, MAX_MULTIBYTE_LENGTH},
     numbers::MOST_POSITIVE_FIXNUM,
     obarray::intern,
     remacs_sys::EmacsInt,
@@ -270,7 +267,7 @@ pub fn self_insert_command(n: EmacsInt) {
                 globals.last_command_event.as_fixnum_or_error() as i32,
             )
         };
-        let val = internal_self_insert(character as Codepoint, n as usize);
+        let val = internal_self_insert(Codepoint::from(character as u32), n as usize);
         if val == 2 {
             set(Qundo_auto__this_command_amalgamating.into(), Qnil);
         }
@@ -309,15 +306,15 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
 
     // At first, get multi-byte form of C in STR.
     if current_buffer.multibyte_characters_enabled() {
-        len = write_codepoint(&mut str, c);
+        len = c.write_to(&mut str);
         if len == 1 {
             c = Codepoint::from(str[0]);
         }
     } else {
-        str[0] = if single_byte_charp(c) {
-            c as u8
+        str[0] = if c.is_single_byte() {
+            c.val() as u8
         } else {
-            char_to_byte8(c)
+            c.to_byte8_unchecked()
         };
         len = 1;
     }
@@ -332,7 +329,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         // C2 and several characters following C2.
 
         // This is the character after point.
-        let c2 = current_buffer.fetch_char(current_buffer.pt_byte) as Codepoint;
+        let c2 = Codepoint::from(current_buffer.fetch_char(current_buffer.pt_byte) as u32);
 
         // Overwriting in binary-mode always replaces C2 by C.
         // Overwriting in textual-mode doesn't always do that.
@@ -341,7 +338,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         // or before a tab if it doesn't use the whole width of the tab.  */
         if overwrite == Qoverwrite_mode_binary {
             chars_to_delete = n as usize;
-        } else if c != '\n' as Codepoint && c2 != '\n' as Codepoint {
+        } else if c != Codepoint::from('\n') && c2 != Codepoint::from('\n') {
             let cwidth = unsafe { Fchar_width(c.into()) }.as_fixnum_or_error() as usize;
             if cwidth > 0 {
                 let pos = current_buffer.pt;
@@ -365,7 +362,9 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
                         // We will delete too many columns.  Let's fill columns
                         // by spaces so that the remaining text won't move.
                         let actual = unsafe { character::dec_pos(current_buffer.pt_byte) };
-                        if current_buffer.fetch_char(actual) as Codepoint == '\t' as Codepoint {
+                        if Codepoint::from(current_buffer.fetch_char(actual) as u32)
+                            == Codepoint::from('\t')
+                        {
                             // Rather than add spaces, let's just keep the tab.
                             chars_to_delete -= 1;
                         } else {
@@ -378,18 +377,18 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
         }
         hairy = 2;
     }
-    synt = unsafe { syntax_property(c as i32, true) };
+    synt = unsafe { syntax_property(c.val() as i32, true) };
 
     let previous_char = if current_buffer.multibyte_characters_enabled() {
-        preceding_char() as Codepoint
+        Codepoint::from(preceding_char() as u32)
     } else {
-        unibyte_to_char(preceding_char() as Codepoint)
+        Codepoint::from(preceding_char() as u32).unibyte_to_char()
     };
     if current_buffer.abbrev_mode_.is_not_nil()
         && synt != syntaxcode::Sword
         && current_buffer.read_only_.is_nil()
         && current_buffer.pt > current_buffer.begv
-        && unsafe { syntax_property(previous_char as libc::c_int, true) } == syntaxcode::Sword
+        && unsafe { syntax_property(previous_char.val() as libc::c_int, true) } == syntaxcode::Sword
     {
         let modiff = unsafe { (*current_buffer.text).modiff };
 
@@ -413,15 +412,15 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
     }
 
     if chars_to_delete > 0 {
-        let mc = if current_buffer.multibyte_characters_enabled() && single_byte_charp(c) {
-            unibyte_to_char(c)
+        let mc = if current_buffer.multibyte_characters_enabled() && c.is_single_byte() {
+            c.unibyte_to_char()
         } else {
             c
         };
         let mut string = unsafe { Fmake_string(n.into(), mc.into(), Qnil) };
         if spaces_to_insert > 0 {
             let tem =
-                unsafe { Fmake_string(spaces_to_insert.into(), (' ' as Codepoint).into(), Qnil) };
+                unsafe { Fmake_string(spaces_to_insert.into(), Codepoint::from(' ').into(), Qnil) };
             string = unsafe { concat2(string, tem) };
         }
 
@@ -451,11 +450,11 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
     }
 
     if let Some(t) = unsafe { globals.Vauto_fill_chars }.as_char_table() {
-        if t.get(c as isize).is_not_nil()
-            && (c == ' ' as Codepoint || c == '\n' as Codepoint)
+        if t.get(c.val() as isize).is_not_nil()
+            && (c == Codepoint::from(' ') || c == Codepoint::from('\n'))
             && current_buffer.auto_fill_function_.is_not_nil()
         {
-            if c == '\n' as Codepoint {
+            if c == Codepoint::from('\n') {
                 // After inserting a newline, move to previous line and fill
                 // that.  Must have the newline in place already so filling and
                 // justification, if any, know where the end is going to be.
@@ -465,7 +464,7 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
             }
             let auto_fill_result = call!(Qinternal_auto_fill);
             // Test PT < ZV in case the auto-fill-function is strange.
-            if c == '\n' as Codepoint && current_buffer.pt < current_buffer.zv {
+            if c == Codepoint::from('\n') && current_buffer.pt < current_buffer.zv {
                 let newpt = current_buffer.pt + 1;
                 let newpt_byte = current_buffer.pt_byte + 1;
                 current_buffer.set_pt_both(newpt, newpt_byte);

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -14,7 +14,7 @@ use crate::{
     lisp::{LispObject, LispSubrRef, LiveBufferIter},
     lists::{get, member, memq, put},
     math::leq,
-    multibyte::{is_ascii, is_single_byte_char, LispStringRef},
+    multibyte::{Codepoint, LispStringRef},
     obarray::{loadhist_attach, map_obarray},
     remacs_sys,
     remacs_sys::Fdelete,
@@ -250,18 +250,18 @@ pub fn aset(array: LispObject, idx: EmacsInt, newelt: LispObject) -> LispObject 
             args_out_of_range!(array, idx);
         }
 
-        let c = newelt.as_character_or_error();
+        let c: Codepoint = newelt.into();
 
         if s.is_multibyte() {
-            unsafe { aset_multibyte_string(array, idx, c as c_int) };
-        } else if is_single_byte_char(c) {
-            s.set_byte(idx as isize, c as u8);
+            unsafe { aset_multibyte_string(array, idx, c.val() as c_int) };
+        } else if c.is_single_byte() {
+            s.set_byte(idx as isize, c.val() as u8);
         } else {
-            if s.chars().any(|i| !is_ascii(i)) {
+            if s.chars().any(|i| !i.is_ascii()) {
                 args_out_of_range!(array, newelt);
             }
             s.mark_as_multibyte();
-            unsafe { aset_multibyte_string(array, idx, c as c_int) };
+            unsafe { aset_multibyte_string(array, idx, c.val() as c_int) };
         }
     } else {
         wrong_type!(Qarrayp, array);

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -437,10 +437,9 @@ pub fn propertize(args: &[LispObject]) -> LispObject {
 /// Convert arg CHAR to a string containing that character.
 /// usage: (char-to-string CHAR)
 #[lisp_fn]
-pub fn char_to_string(character: LispObject) -> LispObject {
-    let c = character.as_character_or_error();
+pub fn char_to_string(character: Codepoint) -> LispObject {
     let mut buffer = [0_u8; MAX_MULTIBYTE_LENGTH];
-    let len = c.write_to(&mut buffer[..]);
+    let len = character.write_to(&mut buffer[..]);
 
     unsafe { make_string_from_bytes(buffer.as_ptr() as *const libc::c_char, 1, len as isize) }
 }
@@ -757,12 +756,7 @@ pub fn byte_to_position(bytepos: EmacsInt) -> Option<EmacsInt> {
 /// Both arguments must be characters (i.e. integers).
 /// Case is ignored if `case-fold-search' is non-nil in the current buffer.
 #[lisp_fn]
-pub fn char_equal(c1: LispObject, c2: LispObject) -> bool {
-    // Check they're chars, not just integers, otherwise we could get array
-    // bounds violations in downcase.
-    let mut c1 = c1.as_character_or_error();
-    let mut c2 = c2.as_character_or_error();
-
+pub fn char_equal(mut c1: Codepoint, mut c2: Codepoint) -> bool {
     if c1 == c2 {
         return true;
     }

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -15,7 +15,7 @@ use crate::{
     lists::{assq, car, get, mapcar1, member, memq, put},
     lists::{LispCons, LispConsCircularChecks, LispConsEndChecks},
     minibuf::read_from_minibuffer,
-    multibyte::{string_char_and_length, write_codepoint, LispStringRef},
+    multibyte::{string_char_and_length, LispStringRef},
     numbers::LispNumber,
     obarray::loadhist_attach,
     objects::equal,
@@ -343,7 +343,7 @@ pub fn reverse(seq: LispObject) -> LispObject {
                     let (c, len) = string_char_and_length(p);
                     p = p.add(len);
                     q = q.sub(len);
-                    write_codepoint(slice::from_raw_parts_mut(q, len), c);
+                    c.write_to(slice::from_raw_parts_mut(q, len));
                 }
             }
             new.into()

--- a/rust_src/src/indent.rs
+++ b/rust_src/src/indent.rs
@@ -103,7 +103,7 @@ pub fn move_to_column(column: EmacsUint, force: LispObject) -> EmacsUint {
         let pos_byte = buffer.dec_pos(buffer.pt_byte);
         let c = buffer.fetch_char(pos_byte);
 
-        if c == '\t' as i32 && prev_col < goal {
+        if c == '\t' && prev_col < goal {
             unsafe {
                 // Insert spaces in front of the tab
                 set_point_both(buffer.pt - 1, buffer.pt_byte - 1);

--- a/rust_src/src/indent.rs
+++ b/rust_src/src/indent.rs
@@ -107,7 +107,11 @@ pub fn move_to_column(column: EmacsUint, force: LispObject) -> EmacsUint {
             unsafe {
                 // Insert spaces in front of the tab
                 set_point_both(buffer.pt - 1, buffer.pt_byte - 1);
-                insert_char(' ' as Codepoint, Some((goal - prev_col) as EmacsInt), true);
+                insert_char(
+                    Codepoint::from(' '),
+                    Some((goal - prev_col) as EmacsInt),
+                    true,
+                );
 
                 // Delete the tab and indent to COL
                 del_range(buffer.pt, buffer.pt + 1);
@@ -163,13 +167,13 @@ pub fn indent_to(column: EmacsInt, minimum: Option<EmacsInt>) -> EmacsInt {
     if unsafe { globals.indent_tabs_mode } {
         let n = mincol / tab_width - fromcol / tab_width;
         if n != 0 {
-            insert_char('\t' as Codepoint, Some(n), true);
+            insert_char(Codepoint::from('\t'), Some(n), true);
             fromcol = (mincol / tab_width) * tab_width;
         }
     }
 
     let missing = mincol - fromcol;
-    insert_char(' ' as Codepoint, Some(missing), true);
+    insert_char(Codepoint::from(' '), Some(missing), true);
 
     unsafe {
         last_known_column = mincol as isize;

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -62,7 +62,7 @@ pub const MAX_1_BYTE_CHAR: u32 = 0x7F;
 
 /// Minimum value for a two byte codepoint
 pub const MIN_2_BYTE_CHAR: u32 = 0x80;
-/// Minimum value for a two byte codepoint
+/// Maximum value for a two byte codepoint
 pub const MAX_2_BYTE_CHAR: u32 = 0x7FF;
 
 /// Minimum value for a three byte codepoint
@@ -99,7 +99,7 @@ impl Codepoint {
     pub fn from_raw(byte: u8) -> Codepoint {
         match Codepoint::from(byte) {
             cp if cp.is_ascii() => cp,
-            cp => Codepoint::from(cp.0 + 0x3F_FF00),
+            cp => Codepoint::from(cp.0 + BYTE8_OFFSET),
         }
     }
 
@@ -184,7 +184,7 @@ impl Codepoint {
     /// enough to hold the resulting bytes. Returns the amount of bytes written
     pub fn write_to(self, to: &mut [u8]) -> usize {
         let cp: u32 = self.into();
-        if cp <= MAX_1_BYTE_CHAR.into() {
+        if cp <= MAX_1_BYTE_CHAR {
             to[0] = cp as u8;
             1
         } else if cp <= MAX_2_BYTE_CHAR {

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -257,6 +257,12 @@ impl Codepoint {
     }
 }
 
+impl PartialEq<char> for Codepoint {
+    fn eq(&self, other: &char) -> bool {
+        self.0 == u32::from(*other)
+    }
+}
+
 impl std::fmt::Display for Codepoint {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match char::try_from(self.0) {
@@ -1053,7 +1059,7 @@ pub unsafe extern "C" fn string_char(
     if !advanced.is_null() {
         *advanced = ptr.add(cplen);
     }
-    cp.0 as c_int
+    cp.val() as c_int
 }
 
 /// Convert eight-bit chars in SRC (in multibyte form) to the


### PR DESCRIPTION
Lots of functions have been made methods on Codepoint instead. There
have also been made lots of changes around the code to accommodate the
type change.

Closes #1501.