### PR TITLE
ThreadRNG causes segfaults.

### DIFF
--- a/rust_src/remacs-lib/files.rs
+++ b/rust_src/remacs-lib/files.rs
@@ -8,7 +8,7 @@ use libc::{self, c_char, c_int, EEXIST, EINVAL};
 #[cfg(unix)]
 use libc::{open, O_CLOEXEC, O_CREAT, O_EXCL, O_RDWR};
 
-use rand::{thread_rng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 
 #[cfg(windows)]
 extern "C" {
@@ -71,7 +71,8 @@ fn generate_temporary_filename(name: &mut String) {
 
     let bytes = &mut name_vec[len - 6..len];
     {
-        thread_rng().fill_bytes(bytes);
+        let mut rng = OsRng::new().unwrap();
+        rng.fill_bytes(bytes);
     }
     for byte in bytes.iter_mut() {
         *byte = match *byte % 62 {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -5,7 +5,7 @@ use std::{self, iter, mem, ops, ptr, slice};
 use field_offset::FieldOffset;
 use libc::{self, c_char, c_uchar, c_void, ptrdiff_t};
 
-use rand::{thread_rng, Rng};
+use rand::{rngs::OsRng, Rng};
 
 use remacs_macros::lisp_fn;
 
@@ -1656,7 +1656,8 @@ pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> Lisp
     }
 
     let basename = if name.byte_at(0) == b' ' {
-        let mut s = format!("-{}", thread_rng().gen_range(0, 1_000_000));
+        let mut rng = OsRng::new().unwrap();
+        let mut s = format!("-{}", rng.gen_range(0, 1_000_000));
         local_unibyte_string!(suffix, s);
         let genname = lisp_concat!(name, suffix);
         if get_buffer(genname.into()).is_none() {


### PR DESCRIPTION
likely because C owns the threads. Fixes MacOS compilation.

Closes: #1425