### PR TITLE
make pretty-printing work in rr

### DIFF
--- a/src/.gdbinit
+++ b/src/.gdbinit
@@ -97,9 +97,9 @@ end
 define pp
   set $tmp = $arg0
   set $output_debug = print_output_debug_flag
-  set print_output_debug_flag = 0
+  call set_output_debug_flag (0)
   call safe_debug_print ($tmp)
-  set print_output_debug_flag = $output_debug
+  call set_output_debug_flag ($output_debug)
 end
 document pp
 Print the argument as an emacs s-expression

--- a/src/print.c
+++ b/src/print.c
@@ -776,12 +776,11 @@ to make it write to the debugging output.  */)
   return character;
 }
 
-/* This function is never called.  Its purpose is to prevent
-   print_output_debug_flag from being optimized away.  */
-
-extern void debug_output_compilation_hack (bool) EXTERNALLY_VISIBLE;
+/* This function is only ever called from gdb. Its primary purpose is
+   to prevent print_output_debug_flag from being optimized away.  */
+extern void set_output_debug_flag (bool) EXTERNALLY_VISIBLE;
 void
-debug_output_compilation_hack (bool x)
+set_output_debug_flag (bool x)
 {
   print_output_debug_flag = x;
 }


### PR DESCRIPTION
This fixes the "Attempt to write memory outside diversion session"
error that you would get when using the `pp` alias.

In order to preserve the correct replay behavior, rr must prevent the
state of the program from diverging from the recording. Thus, any gdb
command which writes to memory (or might do so), needs to be coerced
into writing to freshly-allocated memory which can then be thrown away
after the command is done. rr allocates a 'diversion area' where
writes can happen when we call a function, but it doesn't do this when
we merely try to set a variable (don't ask me why).