### PR TITLE
RFC: Add macro documentation

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -114,7 +114,9 @@ pub const BUF_BYTES_MAX: ptrdiff_t = buf_bytes_max();
 pub type LispBufferRef = ExternalPtr<Lisp_Buffer>;
 pub type LispOverlayRef = ExternalPtr<Lisp_Overlay>;
 
+/// Reference to a lisp buffer
 impl LispBufferRef {
+    /// Create a new buffer with name NAME
     pub fn create_new(name: LispStringRef) -> Self {
         if name.is_empty() {
             error!("Empty string for buffer name is not allowed");
@@ -199,14 +201,16 @@ impl LispBufferRef {
 
         buffer.into()
     }
+    
     pub fn is_read_only(self) -> bool {
         self.read_only_.into()
     }
-
+    /// Equivalent to BEG macro
     pub const fn beg(self) -> ptrdiff_t {
         BEG
     }
 
+    /// Equivalent to BEG_BYTE macro
     pub const fn beg_byte(self) -> ptrdiff_t {
         BEG_BYTE
     }
@@ -421,10 +425,12 @@ impl LispBufferRef {
         unsafe { (*self.text).beg }
     }
 
+    /// Equivalent to GPT macro
     pub fn gpt(self) -> ptrdiff_t {
         unsafe { (*self.text).gpt }
     }
 
+    /// Equivalent to GPT_BYTE macro
     pub fn gpt_byte(self) -> ptrdiff_t {
         unsafe { (*self.text).gpt_byte }
     }
@@ -890,11 +896,14 @@ impl LispBufferRef {
 }
 
 impl LispObject {
+    /// Check if object is a buffer
+    /// Equivalent to BUFFERP
     pub fn is_buffer(self) -> bool {
         self.as_vectorlike()
             .map_or(false, |v| v.is_pseudovector(pvec_type::PVEC_BUFFER))
     }
-
+    /// Convert object to a buffer reference
+    /// Equivalent to XBUFFERP
     pub fn as_buffer(self) -> Option<LispBufferRef> {
         self.into()
     }

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -23,7 +23,7 @@ use crate::{
     remacs_sys::{
         concat as lisp_concat, copy_char_table, globals, make_uninit_bool_vector,
         make_uninit_multibyte_string, make_uninit_string, make_uninit_vector, message1,
-        redisplay_preserve_echo_area,
+        redisplay_preserve_echo_area, CHECK_STRING,
     },
     remacs_sys::{EmacsInt, Lisp_Type},
     remacs_sys::{Fdiscard_input, Fload, Fx_popup_dialog},

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -584,14 +584,18 @@ pub trait LispStructuralEqual {
 }
 
 impl LispObject {
+    /// Check if lisp object is nil.
+    /// Equivalent to NILP macro
     pub fn is_nil(self) -> bool {
         self == Qnil
     }
-
+    /// Check if lisp object is not nil
+    /// Equivalent to !NILP
     pub fn is_not_nil(self) -> bool {
         self != Qnil
     }
 
+    /// Check if object is t
     pub fn is_t(self) -> bool {
         self == Qt
     }

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -33,6 +33,7 @@ impl LispObject {
         }
     }
 
+    /// Equivalent to CHECK_LIST_END macro
     pub fn check_list_end(self, list: Self) {
         if !self.is_nil() {
             wrong_type!(Qlistp, list);
@@ -143,16 +144,23 @@ impl LispObject {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+/// Value specifies if the last item in an iterator must be a valid cons cell or not
+/// off: No checks are performed
+/// on: Signal an error if the last item is not a valid cons cell
 pub enum LispConsEndChecks {
-    off, // no checks
-    on,  // error when the last item inspected is not a valid cons cell.
+    off, 
+    on, 
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+/// Check if the list of cons cells is circular
+/// off: no checks performed
+/// safe: Checked, exit when a circular list is found
+/// on: Signal an error if a circular list is found
 pub enum LispConsCircularChecks {
-    off,  // no checks
-    safe, // checked, exits when a circular list is found.
-    on,   // raises error when a circular list is found.
+    off,  
+    safe,
+    on, 
 }
 
 /// From `FOR_EACH_TAIL_INTERNAL` in `lisp.h`
@@ -358,6 +366,7 @@ impl LispCons {
     }
 
     /// Check that "self" is an impure (i.e. not readonly) cons cell.
+    /// Equivalent to CHECK_IMPURE macro
     pub fn check_impure(self) {
         unsafe {
             CHECK_IMPURE(self.0, self._extract() as *mut c_void);

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -25,6 +25,8 @@ use crate::{
 pub struct LispCons(LispObject);
 
 impl LispObject {
+    /// Check if object is a list and signal an error if not.
+    /// Equivalent to CHECK_LIST macro
     pub fn check_list(self) {
         if !self.is_list() {
             wrong_type!(Qlistp, self);
@@ -37,14 +39,19 @@ impl LispObject {
         }
     }
 
+    /// Check if object is a cons cell
+    /// Equivalent to CONSP macro
     pub fn is_cons(self) -> bool {
         self.get_type() == Lisp_Type::Lisp_Cons
     }
 
+    /// Convert to cons and unwrap. May be unsafe to use!
     pub const fn force_cons(self) -> LispCons {
         LispCons(self)
     }
 
+    /// Convert LispObject to LispCons struct.
+    /// Equivalent to XCONS macro
     pub fn as_cons(self) -> Option<LispCons> {
         if self.is_cons() {
             Some(LispCons(self))
@@ -76,10 +83,13 @@ impl Debug for LispCons {
 }
 
 impl LispObject {
+    /// Create a cons cell. Equivalent to Fcons
     pub fn cons(car: impl Into<Self>, cdr: impl Into<Self>) -> Self {
         unsafe { Fcons(car.into(), cdr.into()) }
     }
 
+    /// Check if object is a list.
+    /// Equivalent to LISTP macro
     pub fn is_list(self) -> bool {
         self.is_cons() || self.is_nil()
     }
@@ -320,16 +330,19 @@ impl LispCons {
     }
 
     /// Return the car (first cell).
+    /// Equivalent to XCAR macro
     pub fn car(self) -> LispObject {
         unsafe { (*self._extract()).u.s.as_ref().car }
     }
 
     /// Return the cdr (second cell).
+    /// Equivalent to XCDR macro
     pub fn cdr(self) -> LispObject {
         unsafe { (*self._extract()).u.s.as_ref().u.cdr }
     }
 
     /// Set the car of the cons cell.
+    /// Equivalent to XSETCAR macro
     pub fn set_car(self, n: impl Into<LispObject>) {
         unsafe {
             (*self._extract()).u.s.as_mut().car = n.into();
@@ -337,6 +350,7 @@ impl LispCons {
     }
 
     /// Set the cdr of the cons cell.
+    /// Equivalent to XSETCDR macro
     pub fn set_cdr(self, n: impl Into<LispObject>) {
         unsafe {
             (*self._extract()).u.s.as_mut().u.cdr = n.into();

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -141,7 +141,9 @@ impl LispObject {
         }
     }
 
-    /// TODO: Bignum support? (Current Emacs doesn't have it)
+    // TODO: Bignum support? (Current Emacs doesn't have it)
+    /// Check if the LispObject is an integer.
+    /// Equivalent to INTEGERP macro
     pub fn is_integer(self) -> bool {
         self.is_fixnum()
     }
@@ -185,6 +187,7 @@ pub fn check_range(num: impl Into<EmacsInt>, from: impl Into<EmacsInt>, to: impl
 }
 
 impl LispNumber {
+    ///
     pub fn to_fixnum(&self) -> EmacsInt {
         match *self {
             LispNumber::Fixnum(v) => v,

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -31,29 +31,39 @@ use crate::{
     threads::ThreadState,
 };
 
+/// Pointer to an emacs lisp symbol
 pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
 impl LispSymbolRef {
+    /// Retrieve the name of a symbol.
+    /// Equivalent to the SYMBOL_NAME macro
     pub fn symbol_name(self) -> LispObject {
         let s = unsafe { self.u.s.as_ref() };
         s.name
     }
 
+    /// Retrieve the name of a symbol.
+    /// Equivalent to the SYMBOL_NAME macro
     pub fn get_function(self) -> LispObject {
         let s = unsafe { self.u.s.as_ref() };
         s.function
     }
-
+    
+    /// Retrieve the plist field of a symbol
     pub fn get_plist(self) -> LispObject {
         let s = unsafe { self.u.s.as_ref() };
         s.plist
     }
 
+    /// Set the plist field of a symbol
+    /// Equivalent to set_symbol_plist
     pub fn set_plist(&mut self, plist: LispObject) {
         let s = unsafe { self.u.s.as_mut() };
         s.plist = plist;
     }
-
+    
+    /// Set the function field of a symbol
+    /// Equivalent to set_symbol_function
     pub fn set_function(&mut self, function: LispObject) {
         let s = unsafe { self.u.s.as_mut() };
         s.function = function;
@@ -87,7 +97,8 @@ impl LispSymbolRef {
     pub fn is_constant(self) -> bool {
         self.get_trapped_write() == symbol_trapped_write::SYMBOL_NOWRITE
     }
-
+    /// Return the alias of a symbol
+    /// Equivalent to SYMBOL_ALIAS macro
     pub unsafe fn get_alias(self) -> Self {
         debug_assert!(self.is_alias());
         let s = self.u.s.as_ref();
@@ -135,14 +146,19 @@ impl LispSymbolRef {
         }
     }
 
+    /// Retrieve the indirect field of a symbol.
+    /// Equivalent to get_symbol_redirect
     pub fn get_redirect(self) -> symbol_redirect {
         unsafe { get_symbol_redirect(self.as_ptr()) }
     }
 
+    /// Set the indirect field of a symbol.
+    /// Equivalent to set_symbol_redirect
     pub fn set_redirect(mut self, v: symbol_redirect) {
         unsafe { set_symbol_redirect(self.as_mut(), v) }
     }
-
+    /// Return the value of a symbol
+    /// Equivalent to SYMBOL_VAL macro
     pub unsafe fn get_value(self) -> LispObject {
         let s = self.u.s.as_ref();
         s.val.value
@@ -306,14 +322,18 @@ impl From<LispObject> for Option<LispSymbolRef> {
 
 // Symbol support (LispType == Lisp_Symbol == 0)
 impl LispObject {
+    /// Check if the LispObject is a symbol.
+    /// Equivalent to SYMBOLP macro
     pub fn is_symbol(self) -> bool {
         self.get_type() == Lisp_Type::Lisp_Symbol
     }
-
+    
+    /// Convert the a LispObject to symbol and unwrap
     pub fn force_symbol(self) -> LispSymbolRef {
         LispSymbolRef::new(self.symbol_ptr_value() as *mut Lisp_Symbol)
     }
 
+    /// Convert the a LispObject to symbol
     pub fn as_symbol(self) -> Option<LispSymbolRef> {
         self.into()
     }


### PR DESCRIPTION
I have been thinking. One of the things which sometimes slows me down is finding the equivalents of some C macros such as `XINT` and others. This might also be a hurdle for anybody who joins the project. Should we begin documenting what the equivalent C macro is for some of the functions which are implemented for `LispObject`, `LispBufferRef` and so on?

We can perhaps document them like as follows(the first line is a bit redundant so perhaps those should be left out):
```rust
    /// Check if object is a cons cell
    /// Equivalent to CONSP macro
    pub fn is_cons(self) -> bool {
        self.get_type() == Lisp_Type::Lisp_Cons
    }
```

If this is done then calling the command `cargo doc --open --document-private-items` and then going to the documentation for `LispObject`(as an example) and searching for `CONSP` will bring the user directly to the`is_cons` function. This will quite possibly speed up the onboarding of new contributors and also make it easier to refresh one's mind when porting over C code.

I have a couple of commits here which will show exactly what type of documentation I am talking about. Its a bit tedious to do but if approved, I have no problem going over the structures and documenting this.