### PR TITLE
Port window-scroll-bar-width and window-scroll-bar-height

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -760,6 +760,22 @@ pub extern "C" fn decode_any_window(window: LispObject) -> LispWindowRef {
     LispWindowOrSelected::from(window).into()
 }
 
+/// Return the width in pixels of WINDOW's vertical scrollbar.
+/// WINDOW must be a live window and defaults to the selected one.
+#[lisp_fn(min = "0")]
+pub fn window_scroll_bar_width(window: LispWindowLiveOrSelected) -> i32 {
+    let win: LispWindowRef = window.into();
+    win.scroll_bar_area_width()
+}
+
+/// Return the height in pixels of WINDOW's horizontal scrollbar.
+/// WINDOW must be a live window and defaults to the selected one.
+#[lisp_fn(min = "0")]
+pub fn window_scroll_bar_height(window: LispWindowLiveOrSelected) -> i32 {
+    let win: LispWindowRef = window.into();
+    win.scroll_bar_area_height()
+}
+
 /// Return the normal height of window WINDOW.
 /// WINDOW must be a valid window and defaults to the selected one.
 /// If HORIZONTAL is non-nil, return the normal width of WINDOW.

--- a/src/window.c
+++ b/src/window.c
@@ -465,24 +465,6 @@ WINDOW must be a live window and defaults to the selected one.  */)
   return (make_number (WINDOW_BOTTOM_DIVIDER_WIDTH (decode_live_window (window))));
 }
 
-DEFUN ("window-scroll-bar-width", Fwindow_scroll_bar_width,
-       Swindow_scroll_bar_width, 0, 1, 0,
-       doc: /* Return the width in pixels of WINDOW's vertical scrollbar.
-WINDOW must be a live window and defaults to the selected one.  */)
-  (Lisp_Object window)
-{
-  return (make_number (WINDOW_SCROLL_BAR_AREA_WIDTH (decode_live_window (window))));
-}
-
-DEFUN ("window-scroll-bar-height", Fwindow_scroll_bar_height,
-       Swindow_scroll_bar_height, 0, 1, 0,
-       doc: /* Return the height in pixels of WINDOW's horizontal scrollbar.
-WINDOW must be a live window and defaults to the selected one.  */)
-  (Lisp_Object window)
-{
-  return (make_number (WINDOW_SCROLL_BAR_AREA_HEIGHT (decode_live_window (window))));
-}
-
 /* Test if the character at column X, row Y is within window W.
    If it is not, return ON_NOTHING;
    if it is on the window's vertical divider, return
@@ -6188,8 +6170,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_header_line_height);
   defsubr (&Swindow_right_divider_width);
   defsubr (&Swindow_bottom_divider_width);
-  defsubr (&Swindow_scroll_bar_width);
-  defsubr (&Swindow_scroll_bar_height);
   defsubr (&Scoordinates_in_window_p);
   defsubr (&Swindow_at);
   defsubr (&Swindow_end);

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -3,7 +3,7 @@
 (ert-deftest window-scroll-bar-width ()
   (let ((w1 (selected-window)))
     (set-window-scroll-bars w1 nil nil nil nil)
-    (should (eq 0 (window-scroll-bar-width wq)))
+    (should (eq 0 (window-scroll-bar-width w1)))
     (set-window-scroll-bars w1 1 'right nil nil)
     (should (eq 1 (window-scroll-bar-width w1)))))
 

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -1,5 +1,17 @@
 (require 'ert)
 
+(ert-deftest window-scroll-bar-width ()
+  (let ((w1 (selected-window)))
+    (set-window-scroll-bars w1 nil nil nil nil)
+    (should (eq 0 (window-scroll-bar-width wq)))
+    (set-window-scroll-bars w1 1 'right nil nil)
+    (should (eq 1 (window-scroll-bar-width w1)))))
+
+(ert-deftest window-scroll-bar-height ()
+  (let ((w1 (selected-window)))
+    (set-window-scroll-bars w1 nil nil nil nil)
+    (should (eq 0 (window-scroll-bar-height w1)))))
+
 (ert-deftest window-display-table-nil ()
   (should (eq (window-display-table) nil)))
 


### PR DESCRIPTION
Hello!

I've added a port for `window-scroll-bar-width` and `window-scroll-bar-height`. Most of the logic was already ported, which made it more straightforward.