### PR TITLE
Port run-window-configuration-change-hook (#1441)

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -21,8 +21,9 @@ use crate::{
     remacs_sys::globals,
     remacs_sys::glyph_row_area::TEXT_AREA,
     remacs_sys::{
-        apply_window_adjustment, estimate_mode_line_height, minibuf_level,
+        apply_window_adjustment, decode_live_frame, estimate_mode_line_height, minibuf_level,
         minibuf_selected_window as current_minibuf_window, noninteractive, record_unwind_protect,
+        run_window_configuration_change_hook as run_window_conf_change_hook,
         save_excursion_restore, save_excursion_save, select_window,
         selected_window as current_window, set_buffer_internal, set_window_fringes,
         update_mode_lines, window_list_1, window_menu_bar_p, window_scroll, window_tool_bar_p,
@@ -2034,3 +2035,15 @@ pub fn window_pixel_height_before_size_change(window: LispWindowValidOrSelected)
 }
 
 include!(concat!(env!("OUT_DIR"), "/windows_exports.rs"));
+
+/// Run `window-configuration-change-hook' for FRAME.
+/// If FRAME is omitted or nil, it defaults to the selected frame.
+#[lisp_fn(min = "0")]
+pub fn run_window_configuration_change_hook(frame: Option<LispObject>) -> LispObject {
+    let f = frame.map_or(Qnil, |obj| obj);
+    unsafe { run_window_conf_change_hook(decode_live_frame(f)) };
+    Qnil
+}
+
+#[rustfmt::skip]
+def_lisp_sym!(Qwindow_configuration_change_hook, "window-configuration-change-hook");

--- a/src/window.c
+++ b/src/window.c
@@ -5925,6 +5925,8 @@ init_window (void)
   Vwindow_list = Qnil;
 }
 
+extern rust_syms_of_window(void);
+
 void
 syms_of_window (void)
 {
@@ -6019,13 +6021,7 @@ on their symbols to be controlled by this variable.  */);
   Vwindow_point_insertion_type = Qnil;
   DEFSYM (Qwindow_point_insertion_type, "window_point_insertion_type");
 
-  DEFVAR_LISP ("window-configuration-change-hook",
-	       Vwindow_configuration_change_hook,
-	       doc: /* Functions to call when window configuration changes.
-The buffer-local value is run once per window, with the relevant window
-selected; while the global value is run only once for the modified frame,
-with the relevant frame selected.  */);
-  Vwindow_configuration_change_hook = Qnil;
+  rust_syms_of_window();
 
   DEFVAR_LISP ("window-size-change-functions", Vwindow_size_change_functions,
     doc: /* Functions called during redisplay, if window sizes have changed.

--- a/src/window.c
+++ b/src/window.c
@@ -5925,7 +5925,7 @@ init_window (void)
   Vwindow_list = Qnil;
 }
 
-extern rust_syms_of_window(void);
+extern void rust_syms_of_window(void);
 
 void
 syms_of_window (void)

--- a/src/window.c
+++ b/src/window.c
@@ -54,7 +54,6 @@ static bool foreach_window_1 (struct window *,
 static bool window_resize_check (struct window *, bool);
 static void window_resize_apply (struct window *, bool);
 static void select_window_1 (Lisp_Object, bool);
-static void run_window_configuration_change_hook (struct frame *);
 
 static struct window *set_window_margins (struct window *, Lisp_Object,
 					  Lisp_Object);
@@ -2193,7 +2192,7 @@ select_frame_norecord (Lisp_Object frame)
     Fselect_frame (frame, Qt);
 }
 
-static void
+void
 run_window_configuration_change_hook (struct frame *f)
 {
   ptrdiff_t count = SPECPDL_INDEX ();
@@ -2241,16 +2240,6 @@ run_window_configuration_change_hook (struct frame *f)
 
   run_funs (global_wcch);
   unbind_to (count, Qnil);
-}
-
-DEFUN ("run-window-configuration-change-hook", Frun_window_configuration_change_hook,
-       Srun_window_configuration_change_hook, 0, 1, 0,
-       doc: /* Run `window-configuration-change-hook' for FRAME.
-If FRAME is omitted or nil, it defaults to the selected frame.  */)
-  (Lisp_Object frame)
-{
-  run_window_configuration_change_hook (decode_live_frame (frame));
-  return Qnil;
 }
 
 DEFUN ("run-window-scroll-functions", Frun_window_scroll_functions,
@@ -5946,7 +5935,6 @@ syms_of_window (void)
   Fput (Qscroll_up, Qscroll_command, Qt);
   Fput (Qscroll_down, Qscroll_command, Qt);
 
-  DEFSYM (Qwindow_configuration_change_hook, "window-configuration-change-hook");
   DEFSYM (Qwindowp, "windowp");
   DEFSYM (Qwindow_configuration_p, "window-configuration-p");
   DEFSYM (Qwindow_live_p, "window-live-p");
@@ -6180,7 +6168,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sdelete_window_internal);
   defsubr (&Sresize_mini_window_internal);
   defsubr (&Sset_window_buffer);
-  defsubr (&Srun_window_configuration_change_hook);
   defsubr (&Srun_window_scroll_functions);
   defsubr (&Sforce_window_update);
   defsubr (&Ssplit_window_internal);

--- a/src/window.h
+++ b/src/window.h
@@ -1128,6 +1128,7 @@ extern Lisp_Object select_window (Lisp_Object window, Lisp_Object norecord,
 extern struct window *set_window_fringes (struct window *w, Lisp_Object left_width,
                                           Lisp_Object right_width, Lisp_Object outside_margins);
 extern void apply_window_adjustment (struct window *);
+extern void run_window_configuration_change_hook (struct frame *);
 
 /* Move cursor to row/column position VPOS/HPOS, pixel coordinates
    Y/X. HPOS/VPOS are window-relative row and column numbers and X/Y

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -201,3 +201,14 @@
 ;; frames inside tests (see https://github.com/remacs/remacs/issues/1429).
 (ert-deftest window-pixel-height-before-size-change ()
   (window-pixel-height-before-size-change))
+
+(ert-deftest run-window-configuration-change-hook ()
+  (setq window-conf-change-hook-val 0)
+  (add-hook 'window-configuration-change-hook
+            (lambda () (setq window-conf-change-hook-val
+                        (+ window-conf-change-hook-val 1))))
+
+  (should (eq (run-window-configuration-change-hook) nil))
+  (should (eq window-conf-change-hook-val 1))
+  (should (eq (run-window-configuration-change-hook (selected-frame)) nil))
+  (should (eq window-conf-change-hook-val 2)))


### PR DESCRIPTION
Hello,
I hope it closes issue #1441 

I have 2 questions.

1. Do I have to port `DEFVAR_LISP ("window-configuration-change-hook", ...)` using `defvar_lisp!`?
2. I've deleted `static` from C source codes. Is it a correct idea?
    * I want to call `run_window_configuration_change_hook` C function from Rust source code