### PR TITLE
[Frame] migrate static variable last_non_minibuffer_frame from C to Rust

### DIFF
--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -729,9 +729,7 @@ pub fn make_frame_invisible(frame: LispFrameLiveOrSelected, force: bool) {
 
 #[lisp_fn]
 pub fn last_nonminibuffer_frame() -> LispObject {
-    unsafe {
-        last_non_minibuffer_frame.into()
-    }
+    unsafe { last_non_minibuffer_frame.into() }
 }
 
 /// A frame to a guaranteed existing frame which is not just a mini-buffer,

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -727,6 +727,17 @@ pub fn make_frame_invisible(frame: LispFrameLiveOrSelected, force: bool) {
     }
 }
 
+#[lisp_fn(min = "0")]
+pub fn last_nonminibuffer_frame() -> LispObject {
+    let frame = get_last_nonminibuffer_frame();
+
+    if frame.is_null() {
+        Qnil
+    } else {
+        frame.into()
+    }
+}
+
 /// A frame which is not just a mini-buffer, or NULL if there are no such
 /// frames. This is usually the most recent such frame that was selected.
 static mut last_non_minibuffer_frame: LispFrameRef = LispFrameRef::new(std::ptr::null_mut());

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -727,6 +727,22 @@ pub fn make_frame_invisible(frame: LispFrameLiveOrSelected, force: bool) {
     }
 }
 
+/// A frame which is not just a mini-buffer, or NULL if there are no such
+/// frames. This is usually the most recent such frame that was selected.
+static mut last_non_minibuffer_frame: LispFrameRef = LispFrameRef::new(std::ptr::null_mut());
+
+/// Return current last non-minibuffer frame reference
+#[no_mangle]
+pub extern "C" fn get_last_nonminibuffer_frame() -> LispFrameRef {
+    unsafe { last_non_minibuffer_frame }
+}
+
+/// Set current last non-minibuffer frame reference
+#[no_mangle]
+pub extern "C" fn set_last_nonminibuffer_frame(frame: LispFrameRef) {
+    unsafe { last_non_minibuffer_frame = frame }
+}
+
 /// Return the value of frame parameter PROP in frame FRAME.
 #[no_mangle]
 pub extern "C" fn get_frame_param(frame: LispFrameRef, prop: LispObject) -> LispObject {

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -727,7 +727,7 @@ pub fn make_frame_invisible(frame: LispFrameLiveOrSelected, force: bool) {
     }
 }
 
-#[lisp_fn(min = "0")]
+#[lisp_fn]
 pub fn last_nonminibuffer_frame() -> LispObject {
     let frame = get_last_nonminibuffer_frame();
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -50,11 +50,6 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 
 Lisp_Object selected_frame;
 
-/* A frame which is not just a mini-buffer, or NULL if there are no such
-   frames.  This is usually the most recent such frame that was selected.  */
-
-static struct frame *last_nonminibuf_frame;
-
 /* False means there are no visible garbaged frames.  */
 bool frame_garbaged;
 
@@ -996,7 +991,7 @@ make_initial_frame (void)
   if (!noninteractive)
     init_frame_faces (f);
 
-  last_nonminibuf_frame = f;
+  set_last_nonminibuffer_frame(f);
 
   f->can_x_set_window_size = true;
   f->after_make_frame = true;
@@ -1298,7 +1293,7 @@ do_switch_frame (Lisp_Object frame, int track, int for_deletion, Lisp_Object nor
 
   selected_frame = frame;
   if (! FRAME_MINIBUF_ONLY_P (XFRAME (selected_frame)))
-    last_nonminibuf_frame = XFRAME (selected_frame);
+    set_last_nonminibuffer_frame(XFRAME (selected_frame));
 
   Fselect_window (f->selected_window, norecord);
 
@@ -1481,6 +1476,7 @@ DEFUN ("last-nonminibuffer-frame", Flast_nonminibuf_frame,
   (void)
 {
   Lisp_Object frame = Qnil;
+  struct frame *last_nonminibuf_frame = (struct frame *) get_last_nonminibuffer_frame();
 
   if (last_nonminibuf_frame)
     XSETFRAME (frame, last_nonminibuf_frame);
@@ -1850,9 +1846,10 @@ delete_frame (Lisp_Object frame, Lisp_Object force)
 
   /* If we've deleted the last_nonminibuf_frame, then try to find
      another one.  */
+  struct frame *last_nonminibuf_frame = (struct frame *) get_last_nonminibuffer_frame();
   if (f == last_nonminibuf_frame)
     {
-      last_nonminibuf_frame = 0;
+      set_last_nonminibuffer_frame(0);
 
       FOR_EACH_FRAME (frames, frame1)
 	{
@@ -1860,7 +1857,7 @@ delete_frame (Lisp_Object frame, Lisp_Object force)
 
 	  if (!FRAME_MINIBUF_ONLY_P (f1))
 	    {
-	      last_nonminibuf_frame = f1;
+	      set_last_nonminibuffer_frame(f1);
 	      break;
 	    }
 	}

--- a/src/frame.c
+++ b/src/frame.c
@@ -1470,20 +1470,6 @@ candidate_frame (Lisp_Object candidate, Lisp_Object frame, Lisp_Object minibuf)
   return Qnil;
 }
 
-DEFUN ("last-nonminibuffer-frame", Flast_nonminibuf_frame,
-       Slast_nonminibuf_frame, 0, 0, 0,
-       doc: /* Return last non-minibuffer frame selected. */)
-  (void)
-{
-  Lisp_Object frame = Qnil;
-  struct frame *last_nonminibuf_frame = (struct frame *) get_last_nonminibuffer_frame();
-
-  if (last_nonminibuf_frame)
-    XSETFRAME (frame, last_nonminibuf_frame);
-
-  return frame;
-}
-
 /**
  * other_frames:
  *
@@ -1846,7 +1832,7 @@ delete_frame (Lisp_Object frame, Lisp_Object force)
 
   /* If we've deleted the last_nonminibuf_frame, then try to find
      another one.  */
-  struct frame *last_nonminibuf_frame = (struct frame *) get_last_nonminibuffer_frame();
+  struct frame *last_nonminibuf_frame = get_last_nonminibuffer_frame();
   if (f == last_nonminibuf_frame)
     {
       set_last_nonminibuffer_frame(0);
@@ -5557,7 +5543,6 @@ iconify the top level frame instead.  */);
   defsubr (&Sselect_frame);
   defsubr (&Sframe_parent);
   defsubr (&Sframe_ancestor_p);
-  defsubr (&Slast_nonminibuf_frame);
   defsubr (&Smouse_position);
   defsubr (&Smouse_pixel_position);
   defsubr (&Sset_mouse_position);

--- a/src/frame.h
+++ b/src/frame.h
@@ -1552,6 +1552,9 @@ extern void x_free_frame_resources (struct frame *);
 extern bool frame_ancestor_p (struct frame *af, struct frame *df);
 extern enum internal_border_part frame_internal_border_part (struct frame *f, int x, int y);
 
+extern void set_last_nonminibuffer_frame(struct frame *);
+extern struct frame *get_last_nonminibuffer_frame(void);
+
 int fget_internal_border_width(const struct frame *);
 Lisp_Object fget_minibuffer_window(const struct frame *);
 Lisp_Object fget_root_window(const struct frame *);

--- a/src/frame.h
+++ b/src/frame.h
@@ -1552,9 +1552,6 @@ extern void x_free_frame_resources (struct frame *);
 extern bool frame_ancestor_p (struct frame *af, struct frame *df);
 extern enum internal_border_part frame_internal_border_part (struct frame *f, int x, int y);
 
-extern void set_last_nonminibuffer_frame(struct frame *);
-extern struct frame *get_last_nonminibuffer_frame(void);
-
 int fget_internal_border_width(const struct frame *);
 Lisp_Object fget_minibuffer_window(const struct frame *);
 Lisp_Object fget_root_window(const struct frame *);

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4309,6 +4309,8 @@ extern Lisp_Object do_switch_frame (Lisp_Object, int, int, Lisp_Object);
 extern Lisp_Object get_frame_param (struct frame *, Lisp_Object);
 extern void frames_discard_buffer (Lisp_Object);
 extern void syms_of_frame (void);
+extern void set_last_nonminibuffer_frame(struct frame *);
+extern struct frame *get_last_nonminibuffer_frame(void);
 
 /* Defined in emacs.c.  */
 extern char **initial_argv;


### PR DESCRIPTION
Original function to port, which is defined in the ticket/issue #1418 `last-nonminibuffer-frame` is accessing a global static variable (which afaik is not accessible from Rust, cause it's sort of fileprivate)

This variable is used in other functions as well, so in order to port this function, I decided to firstly, port the static variable itself.
All accesses to it in C are done via function calling (get/set) to Rust