### PR TITLE
Remove most uses of transmute

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -232,7 +232,8 @@ impl LispBufferRef {
     }
 
     pub fn markers(self) -> Option<LispMarkerRef> {
-        unsafe { (*self.text).markers.as_ref().map(|m| mem::transmute(m)) }
+        let markers = unsafe { (*self.text).markers };
+        LispMarkerRef::from_ptr(markers as *mut _)
     }
 
     pub fn mark_active(self) -> LispObject {
@@ -720,11 +721,11 @@ impl LispBufferRef {
     }
 
     pub fn overlays_before(self) -> Option<LispOverlayRef> {
-        unsafe { self.overlays_before.as_ref().map(|m| mem::transmute(m)) }
+        LispOverlayRef::from_ptr(self.overlays_before as *mut _)
     }
 
     pub fn overlays_after(self) -> Option<LispOverlayRef> {
-        unsafe { self.overlays_after.as_ref().map(|m| mem::transmute(m)) }
+        LispOverlayRef::from_ptr(self.overlays_after as *mut _)
     }
 
     pub fn as_live(self) -> Option<Self> {
@@ -954,7 +955,7 @@ impl From<LispObject> for Option<LispOverlayRef> {
 impl LispMiscRef {
     pub fn as_overlay(self) -> Option<LispOverlayRef> {
         if self.get_type() == Lisp_Misc_Type::Lisp_Misc_Overlay {
-            unsafe { Some(mem::transmute(self)) }
+            Some(LispOverlayRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -233,7 +233,7 @@ impl LispBufferRef {
 
     pub fn markers(self) -> Option<LispMarkerRef> {
         let markers = unsafe { (*self.text).markers };
-        LispMarkerRef::from_ptr(markers as *mut _)
+        ExternalPtr::from_ptr(markers.cast())
     }
 
     pub fn mark_active(self) -> LispObject {
@@ -721,11 +721,11 @@ impl LispBufferRef {
     }
 
     pub fn overlays_before(self) -> Option<LispOverlayRef> {
-        LispOverlayRef::from_ptr(self.overlays_before as *mut _)
+        ExternalPtr::from_ptr(self.overlays_before.cast())
     }
 
     pub fn overlays_after(self) -> Option<LispOverlayRef> {
-        LispOverlayRef::from_ptr(self.overlays_after as *mut _)
+        ExternalPtr::from_ptr(self.overlays_after.cast())
     }
 
     pub fn as_live(self) -> Option<Self> {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -955,7 +955,7 @@ impl From<LispObject> for Option<LispOverlayRef> {
 impl LispMiscRef {
     pub fn as_overlay(self) -> Option<LispOverlayRef> {
         if self.get_type() == Lisp_Misc_Type::Lisp_Misc_Overlay {
-            Some(LispOverlayRef::new(self.as_ptr() as *mut _))
+            unsafe { Some(mem::transmute(self)) }
         } else {
             None
         }

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,10 +1,9 @@
 //! font support
 
+use std::ffi::CString;
 use std::ptr;
 
 use remacs_macros::lisp_fn;
-
-use std::{ffi::CString, mem};
 
 use crate::{
     data, fns,
@@ -161,7 +160,7 @@ impl From<LispObject> for Option<LispFontObjectRef> {
     fn from(o: LispObject) -> Self {
         o.as_vectorlike().and_then(|v| {
             if v.is_pseudovector(pvec_type::PVEC_FONT) && o.is_font_object() {
-                Some(unsafe { mem::transmute(o) })
+                Some(LispFontObjectRef::new(v.as_ptr() as *mut _))
             } else {
                 None
             }
@@ -190,7 +189,7 @@ impl From<LispObject> for Option<LispFontSpecRef> {
     fn from(o: LispObject) -> Self {
         o.as_vectorlike().and_then(|v| {
             if v.is_pseudovector(pvec_type::PVEC_FONT) && o.is_font_spec() {
-                Some(unsafe { mem::transmute(v) })
+                Some(LispFontSpecRef::new(v.as_ptr() as *mut _))
             } else {
                 None
             }

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -160,7 +160,7 @@ impl From<LispObject> for Option<LispFontObjectRef> {
     fn from(o: LispObject) -> Self {
         o.as_vectorlike().and_then(|v| {
             if v.is_pseudovector(pvec_type::PVEC_FONT) && o.is_font_object() {
-                Some(LispFontObjectRef::new(v.as_ptr() as *mut _))
+                Some(v.cast())
             } else {
                 None
             }
@@ -189,7 +189,7 @@ impl From<LispObject> for Option<LispFontSpecRef> {
     fn from(o: LispObject) -> Self {
         o.as_vectorlike().and_then(|v| {
             if v.is_pseudovector(pvec_type::PVEC_FONT) && o.is_font_spec() {
-                Some(LispFontSpecRef::new(v.as_ptr() as *mut _))
+                Some(v.cast())
             } else {
                 None
             }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(specialization)]
 #![feature(stmt_expr_attributes)]
 #![feature(untagged_unions)]
+#![feature(ptr_cast)]
 
 extern crate errno;
 #[macro_use]

--- a/rust_src/src/libm.rs
+++ b/rust_src/src/libm.rs
@@ -1,5 +1,4 @@
 use libc::c_int;
-use std::mem;
 
 mod sys {
     use libc::{c_double, c_int};
@@ -14,8 +13,7 @@ mod sys {
 
 /// Return the sign bit of the float.
 pub fn signbit(x: f64) -> bool {
-    let bits: u64 = unsafe { mem::transmute(x) };
-    bits >> 63 != 0
+    x.is_sign_negative()
 }
 
 /// Split the number `x` into a normalized fraction and an exponent.
@@ -34,4 +32,19 @@ pub fn ldexp(x: f64, exp: c_int) -> f64 {
 /// Round `x` to an integer value in floating-point format.
 pub fn rint(x: f64) -> f64 {
     unsafe { sys::rint(x) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::signbit;
+
+    #[test]
+    fn test_signbit() {
+        assert!(signbit(-1f64));
+        assert!(signbit(-0f64));
+        assert!(signbit(-std::f64::NAN));
+        assert!(!signbit(std::f64::NAN));
+        assert!(!signbit(0f64));
+        assert!(!signbit(1f64));
+    }
 }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -176,6 +176,12 @@ impl<T> PartialOrd for ExternalPtr<T> {
     }
 }
 
+impl<T> From<*mut T> for ExternalPtr<T> {
+    fn from(o: *mut T) -> Self {
+        Self::new(o)
+    }
+}
+
 // Misc support (LispType == Lisp_Misc == 1)
 
 // Lisp_Misc is a union. Now we don't really care about its variants except the

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -145,6 +145,10 @@ impl<T> ExternalPtr<T> {
         let ptr = self.0.sub(size);
         self.replace_ptr(ptr);
     }
+
+    pub fn cast<U>(mut self) -> ExternalPtr<U> {
+        ExternalPtr::<U>(self.as_mut().cast())
+    }
 }
 
 impl<T> Deref for ExternalPtr<T> {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -120,7 +120,11 @@ impl<T> ExternalPtr<T> {
     }
 
     pub fn from_ptr(ptr: *mut c_void) -> Option<Self> {
-        unsafe { ptr.as_ref().map(|p| mem::transmute(p)) }
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr as *mut T))
+        }
     }
 
     pub fn replace_ptr(&mut self, ptr: *mut T) {

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -138,7 +138,7 @@ impl LispObject {
 impl LispMiscRef {
     pub fn as_marker(self) -> Option<LispMarkerRef> {
         if self.get_type() == Lisp_Misc_Type::Lisp_Misc_Marker {
-            LispMarkerRef::from_ptr(self.as_ptr() as *mut _)
+            Some(self.cast())
         } else {
             None
         }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -58,7 +58,7 @@ impl LispMarkerRef {
     }
 
     pub fn buffer(self) -> Option<LispBufferRef> {
-        LispBufferRef::from_ptr(self.buffer as *mut _)
+        ExternalPtr::from_ptr(self.buffer.cast())
     }
 
     pub fn set_buffer(mut self, b: *mut Lisp_Buffer) {
@@ -72,7 +72,7 @@ impl LispMarkerRef {
     }
 
     pub fn next(self) -> Option<Self> {
-        Self::from_ptr(self.next as *mut _)
+        Self::from_ptr(self.next.cast())
     }
 
     pub fn set_next(mut self, m: *mut Lisp_Marker) {

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,6 @@
 //! marker support
 
 use libc::{c_void, ptrdiff_t};
-use std::mem;
 use std::ptr;
 
 use remacs_macros::lisp_fn;
@@ -59,7 +58,7 @@ impl LispMarkerRef {
     }
 
     pub fn buffer(self) -> Option<LispBufferRef> {
-        unsafe { self.buffer.as_ref().map(|b| mem::transmute(b)) }
+        LispBufferRef::from_ptr(self.buffer as *mut _)
     }
 
     pub fn set_buffer(mut self, b: *mut Lisp_Buffer) {
@@ -73,7 +72,7 @@ impl LispMarkerRef {
     }
 
     pub fn next(self) -> Option<Self> {
-        unsafe { self.next.as_ref().map(|n| mem::transmute(n)) }
+        Self::from_ptr(self.next as *mut _)
     }
 
     pub fn set_next(mut self, m: *mut Lisp_Marker) {
@@ -139,7 +138,7 @@ impl LispObject {
 impl LispMiscRef {
     pub fn as_marker(self) -> Option<LispMarkerRef> {
         if self.get_type() == Lisp_Misc_Type::Lisp_Misc_Marker {
-            unsafe { Some(mem::transmute(self)) }
+            LispMarkerRef::from_ptr(self.as_ptr() as *mut _)
         } else {
             None
         }

--- a/rust_src/src/terminal.rs
+++ b/rust_src/src/terminal.rs
@@ -36,7 +36,7 @@ impl LispTerminalRef {
 impl LispVectorlikeRef {
     pub fn as_terminal(self) -> Option<LispTerminalRef> {
         if self.is_pseudovector(pvec_type::PVEC_TERMINAL) {
-            Some(LispTerminalRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }

--- a/rust_src/src/terminal.rs
+++ b/rust_src/src/terminal.rs
@@ -1,6 +1,6 @@
 //! Functions related to terminal devices.
 
-use std::{mem, ptr};
+use std::ptr;
 
 use libc::{c_int, c_void};
 
@@ -36,7 +36,7 @@ impl LispTerminalRef {
 impl LispVectorlikeRef {
     pub fn as_terminal(self) -> Option<LispTerminalRef> {
         if self.is_pseudovector(pvec_type::PVEC_TERMINAL) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispTerminalRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -1,7 +1,5 @@
 //! Threading code.
 
-use std::mem;
-
 use libc;
 
 use remacs_macros::lisp_fn;
@@ -22,7 +20,7 @@ pub struct ThreadState {}
 
 impl ThreadState {
     pub fn current_buffer_unchecked() -> LispBufferRef {
-        unsafe { mem::transmute((*current_thread_pointer).m_current_buffer) }
+        unsafe { LispBufferRef::new((*current_thread_pointer).m_current_buffer as *mut _) }
     }
 
     pub fn current_buffer() -> Option<LispBufferRef> {
@@ -32,7 +30,7 @@ impl ThreadState {
     }
 
     pub fn current_thread() -> ThreadStateRef {
-        unsafe { mem::transmute(current_thread_pointer) }
+        unsafe { ThreadStateRef::new(current_thread_pointer as *mut _) }
     }
 }
 

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -20,7 +20,7 @@ pub struct ThreadState {}
 
 impl ThreadState {
     pub fn current_buffer_unchecked() -> LispBufferRef {
-        unsafe { LispBufferRef::new((*current_thread_pointer).m_current_buffer as *mut _) }
+        unsafe { (*current_thread_pointer).m_current_buffer.into() }
     }
 
     pub fn current_buffer() -> Option<LispBufferRef> {
@@ -30,7 +30,7 @@ impl ThreadState {
     }
 
     pub fn current_thread() -> ThreadStateRef {
-        unsafe { ThreadStateRef::new(current_thread_pointer as *mut _) }
+        unsafe { current_thread_pointer.into() }
     }
 }
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -21,9 +21,9 @@ use crate::{
     multibyte::MAX_CHAR,
     process::LispProcessRef,
     remacs_sys::{
-        equal_kind, pvec_type, EmacsInt, Lisp_Bool_Vector, Lisp_Char_Table, Lisp_Type, Lisp_Vector,
-        Lisp_Vectorlike, Lisp_Vectorlike_With_Slots, More_Lisp_Bits, BITS_PER_BITS_WORD,
-        BOOL_VECTOR_BITS_PER_CHAR, PSEUDOVECTOR_FLAG,
+        equal_kind, pvec_type, EmacsInt, Lisp_Bool_Vector, Lisp_Type, Lisp_Vector, Lisp_Vectorlike,
+        Lisp_Vectorlike_With_Slots, More_Lisp_Bits, BITS_PER_BITS_WORD, BOOL_VECTOR_BITS_PER_CHAR,
+        PSEUDOVECTOR_FLAG,
     },
     remacs_sys::{Qarrayp, Qsequencep, Qvectorp},
     threads::ThreadStateRef,
@@ -153,14 +153,14 @@ impl LispVectorlikeRef {
 
     pub fn as_vector(self) -> Option<LispVectorRef> {
         if self.is_vector() {
-            Some(LispVectorRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
     }
 
     pub unsafe fn as_vector_unchecked(self) -> LispVectorRef {
-        LispVectorRef::new(self.as_ptr() as *mut _)
+        self.cast()
     }
 
     pub fn pseudovector_type(self) -> pvec_type {
@@ -188,7 +188,7 @@ impl LispVectorlikeRef {
 
     pub fn as_bool_vector(self) -> Option<LispBoolVecRef> {
         if self.is_pseudovector(pvec_type::PVEC_BOOL_VECTOR) {
-            Some(LispBoolVecRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -196,7 +196,7 @@ impl LispVectorlikeRef {
 
     pub fn as_buffer(self) -> Option<LispBufferRef> {
         if self.is_pseudovector(pvec_type::PVEC_BUFFER) {
-            Some(LispBufferRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -204,7 +204,7 @@ impl LispVectorlikeRef {
 
     pub fn as_subr(self) -> Option<LispSubrRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUBR) {
-            Some(LispSubrRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -212,7 +212,7 @@ impl LispVectorlikeRef {
 
     pub fn as_window(self) -> Option<LispWindowRef> {
         if self.is_pseudovector(pvec_type::PVEC_WINDOW) {
-            Some(LispWindowRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -220,7 +220,7 @@ impl LispVectorlikeRef {
 
     pub fn as_window_configuration(self) -> Option<SaveWindowDataRef> {
         if self.is_pseudovector(pvec_type::PVEC_WINDOW_CONFIGURATION) {
-            Some(SaveWindowDataRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -228,7 +228,7 @@ impl LispVectorlikeRef {
 
     pub fn as_frame(self) -> Option<LispFrameRef> {
         if self.is_pseudovector(pvec_type::PVEC_FRAME) {
-            Some(LispFrameRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -236,7 +236,7 @@ impl LispVectorlikeRef {
 
     pub fn as_process(self) -> Option<LispProcessRef> {
         if self.is_pseudovector(pvec_type::PVEC_PROCESS) {
-            Some(LispProcessRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -244,15 +244,15 @@ impl LispVectorlikeRef {
 
     pub fn as_thread(self) -> Option<ThreadStateRef> {
         if self.is_pseudovector(pvec_type::PVEC_THREAD) {
-            Some(ThreadStateRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
     }
 
-    pub fn as_char_table(mut self) -> Option<LispCharTableRef> {
+    pub fn as_char_table(self) -> Option<LispCharTableRef> {
         if self.is_pseudovector(pvec_type::PVEC_CHAR_TABLE) {
-            Some(LispCharTableRef::new(self.as_mut() as *mut Lisp_Char_Table))
+            Some(self.cast())
         } else {
             None
         }
@@ -260,7 +260,7 @@ impl LispVectorlikeRef {
 
     pub fn as_sub_char_table(self) -> Option<LispSubCharTableRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUB_CHAR_TABLE) {
-            Some(LispSubCharTableRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -276,7 +276,7 @@ impl LispVectorlikeRef {
 
     pub fn as_compiled(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_COMPILED) {
-            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -284,7 +284,7 @@ impl LispVectorlikeRef {
 
     pub fn as_record(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_RECORD) {
-            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }
@@ -292,7 +292,7 @@ impl LispVectorlikeRef {
 
     pub fn as_font(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_FONT) {
-            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
+            Some(self.cast())
         } else {
             None
         }

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -153,14 +153,14 @@ impl LispVectorlikeRef {
 
     pub fn as_vector(self) -> Option<LispVectorRef> {
         if self.is_vector() {
-            Some(unsafe { mem::transmute::<_, LispVectorRef>(self) })
+            Some(LispVectorRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
     }
 
     pub unsafe fn as_vector_unchecked(self) -> LispVectorRef {
-        mem::transmute::<_, LispVectorRef>(self)
+        LispVectorRef::new(self.as_ptr() as *mut _)
     }
 
     pub fn pseudovector_type(self) -> pvec_type {
@@ -188,7 +188,7 @@ impl LispVectorlikeRef {
 
     pub fn as_bool_vector(self) -> Option<LispBoolVecRef> {
         if self.is_pseudovector(pvec_type::PVEC_BOOL_VECTOR) {
-            Some(unsafe { mem::transmute::<_, LispBoolVecRef>(self) })
+            Some(LispBoolVecRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -196,7 +196,7 @@ impl LispVectorlikeRef {
 
     pub fn as_buffer(self) -> Option<LispBufferRef> {
         if self.is_pseudovector(pvec_type::PVEC_BUFFER) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispBufferRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -204,7 +204,7 @@ impl LispVectorlikeRef {
 
     pub fn as_subr(self) -> Option<LispSubrRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUBR) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispSubrRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -212,7 +212,7 @@ impl LispVectorlikeRef {
 
     pub fn as_window(self) -> Option<LispWindowRef> {
         if self.is_pseudovector(pvec_type::PVEC_WINDOW) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispWindowRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -220,7 +220,7 @@ impl LispVectorlikeRef {
 
     pub fn as_window_configuration(self) -> Option<SaveWindowDataRef> {
         if self.is_pseudovector(pvec_type::PVEC_WINDOW_CONFIGURATION) {
-            Some(unsafe { mem::transmute(self) })
+            Some(SaveWindowDataRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -228,7 +228,7 @@ impl LispVectorlikeRef {
 
     pub fn as_frame(self) -> Option<LispFrameRef> {
         if self.is_pseudovector(pvec_type::PVEC_FRAME) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispFrameRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -236,7 +236,7 @@ impl LispVectorlikeRef {
 
     pub fn as_process(self) -> Option<LispProcessRef> {
         if self.is_pseudovector(pvec_type::PVEC_PROCESS) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispProcessRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -244,7 +244,7 @@ impl LispVectorlikeRef {
 
     pub fn as_thread(self) -> Option<ThreadStateRef> {
         if self.is_pseudovector(pvec_type::PVEC_THREAD) {
-            Some(unsafe { mem::transmute(self) })
+            Some(ThreadStateRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -260,7 +260,7 @@ impl LispVectorlikeRef {
 
     pub fn as_sub_char_table(self) -> Option<LispSubCharTableRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUB_CHAR_TABLE) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispSubCharTableRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -276,7 +276,7 @@ impl LispVectorlikeRef {
 
     pub fn as_compiled(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_COMPILED) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -284,7 +284,7 @@ impl LispVectorlikeRef {
 
     pub fn as_record(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_RECORD) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }
@@ -292,7 +292,7 @@ impl LispVectorlikeRef {
 
     pub fn as_font(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_FONT) {
-            Some(unsafe { mem::transmute(self) })
+            Some(LispVectorlikeSlotsRef::new(self.as_ptr() as *mut _))
         } else {
             None
         }


### PR DESCRIPTION
Almost every single transmute is used to cast between versions of `ExternalPtr<T>` and we can instead get away with casting the pointers.

I wondered about using some `From<ExternalPtr<U>> for ExternalPointer<T>` but these are behind a type check so I thought maybe it shouldn't be *that* easy to convert between them.

This handles most of #1208 although there are a couple of uses which aren't nearly as clear-cut which I've left out of this PR.