### PR TITLE
Detect when rustup upgrades the local Rust version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,14 @@ jobs:
       os: linux  # No need to run this everywhere
       before_script:
         - travis_wait rustup install $(cat rust-toolchain)
-        - travis_wait rustup component add rustfmt-preview
+        - travis_wait rustup component add rustfmt
         - ./autogen.sh && ./configure --without-makeinfo --with-x=no --with-ns=no --without-gconf --without-gsettings
       script: ./.travis-format.sh
     - stage: clippy
       os: linux  # No need to run this everywhere
       before_script:
         - sudo apt install -y libgtk-3-dev
-        - travis_wait rustup component add clippy-preview
+        - travis_wait rustup component add clippy
         - ./autogen.sh && ./configure --without-makeinfo
       script:
         - make clippy

--- a/autogen.sh
+++ b/autogen.sh
@@ -189,7 +189,7 @@ if [ -n $rust_toolchain_vers_path ] ; then
     retval=$?
 
     case $retval in
-        0) echo "Your system has the required Rust toolchain installed for building Remacs." ;;
+        0|3) echo "Your system has the required Rust toolchain installed for building Remacs." ;;
         1) echo >&2 "Remacs currently requires Rust toolchain version $remacs_version."
 	   echo >&2 "Run 'rustup install $remacs_version'."
 	   exit 1 ;;
@@ -198,7 +198,7 @@ if [ -n $rust_toolchain_vers_path ] ; then
 	   echo >&2 "Run 'rustup override unset' in this directory."
 	   exit 1 ;;
         *) # /should/ not happen
-	   echo >&2 "Remacs currently requires Rust toolchain version $remacs_version."
+	   echo >&2 "Assertion failed: Remacs currently requires Rust toolchain version $remacs_version: rustup returned $retval."
 	   exit 1 ;;
     esac
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -159,6 +159,7 @@ check_rust_version ()
     # Instead, let's use 'toolchain list' which is idempotent and makes no changes.
     # When cargo begins to compile the rust-toolchain file will be honored so no further work is needed.
     rustup toolchain list | grep -q $remacs_version
+    retval=$?
     return $retval
 }
 


### PR DESCRIPTION
autogen.sh was failing because the return value of rustup was not
understood which lead to an assertion.

Simplify the rustup and rust version checks by using `rustup toolchain list` which does not try to update the system.

Closes: #1549