### PR TITLE
Port keybindings and supports.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5466,8 +5466,14 @@ fi || AC_MSG_ERROR(['src/epaths.h' could not be made.])
 
 
 CARGO_DEFAULT_FEATURES=""
+if test "$HAVE_DBUS" = "yes"; then
+    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-dbus\", "
+fi
 if test "$HAVE_LIBXML2" = "yes"; then
     CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-xml2\", "
+fi
+if test "$USE_FILE_NOTIFY" = "yes"; then
+    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-file-notify\", "
 fi
 if test "$CANNOT_DUMP" != "yes"; then
     if test "$opsys" = "darwin"; then

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -67,6 +67,10 @@ unexecmacosx = ["alloc_unexecmacosx"]
 unexec = []
 # Compile with C xml2 library support.
 use-xml2 = []
+# Compile with C DBUS support.
+use-dbus = []
+# Compile with File notify support.
+use-file-notify = []
 # Use a window system
 window-system = []
 # Use the x11 window system

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -1,17 +1,15 @@
 //! Case conversion functions.
-use std::ffi::CString;
-
 use remacs_macros::lisp_fn;
 
 use crate::{
-    keymap::Ctl,
+    keymap::{initial_define_key, Ctl, KeyChar},
     lisp::LispObject,
     lists::put,
     lists::{LispConsCircularChecks, LispConsEndChecks},
     obarray::intern,
     remacs_sys::EmacsInt,
     remacs_sys::{case_action, casify_object, casify_region},
-    remacs_sys::{control_x_map, initial_define_key, meta_map, scan_words, set_point},
+    remacs_sys::{control_x_map, meta_map, scan_words, set_point},
     remacs_sys::{Qdisabled, Qt},
     symbols::symbol_value,
     threads::ThreadState,
@@ -200,20 +198,15 @@ pub extern "C" fn syms_of_casefiddle() {
 #[no_mangle]
 pub extern "C" fn keys_of_casefiddle() {
     unsafe {
-        let downcase_region = CString::new("downcase-region").unwrap();
-        initial_define_key(control_x_map, Ctl('L'), downcase_region.as_ptr());
-        let upcase_region = CString::new("upcase-region").unwrap();
-        initial_define_key(control_x_map, Ctl('U'), upcase_region.as_ptr());
-        let capitalize_word = CString::new("capitalize-word").unwrap();
-        initial_define_key(meta_map, 'c' as i32, capitalize_word.as_ptr());
-        let downcase_word = CString::new("downcase-word").unwrap();
-        initial_define_key(meta_map, 'l' as i32, downcase_word.as_ptr());
-        let upcase_word = CString::new("upcase-word").unwrap();
-        initial_define_key(meta_map, 'u' as i32, upcase_word.as_ptr());
-    }
+        initial_define_key(control_x_map, Ctl('U'), "upcase-region");
+        put(intern("upcase-region"), Qdisabled, Qt);
+        initial_define_key(control_x_map, Ctl('L'), "downcase-region");
+        put(intern("downcase-region"), Qdisabled, Qt);
 
-    put(intern("upcase-region"), Qdisabled, Qt);
-    put(intern("downcase-region"), Qdisabled, Qt);
+        initial_define_key(meta_map, KeyChar('u'), "upcase-word");
+        initial_define_key(meta_map, KeyChar('l'), "downcase-word");
+        initial_define_key(meta_map, KeyChar('c'), "capitalize-word");
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/casefiddle_exports.rs"));

--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -1,8 +1,8 @@
 //! Commands
 
-use libc;
 use std;
-use std::ffi::CString;
+
+use libc;
 
 use remacs_macros::lisp_fn;
 
@@ -12,7 +12,7 @@ use crate::{
     dispnew::ding_internal,
     editfns::{insert_and_inherit, line_beginning_position, line_end_position, preceding_char},
     frame::selected_frame,
-    keymap::{current_global_map, Ctl},
+    keymap::{current_global_map, initial_define_key, Ctl},
     lisp::LispObject,
     lists::get,
     multibyte::{Codepoint, MAX_MULTIBYTE_LENGTH},
@@ -20,9 +20,9 @@ use crate::{
     obarray::intern,
     remacs_sys::EmacsInt,
     remacs_sys::{
-        concat2, current_column, del_range, frame_make_pointer_invisible, globals,
-        initial_define_key, memory_full, replace_range, run_hook, scan_newline_from_point,
-        set_point, set_point_both, syntax_property, syntaxcode, translate_char,
+        concat2, current_column, del_range, frame_make_pointer_invisible, globals, memory_full,
+        replace_range, run_hook, scan_newline_from_point, set_point, set_point_both,
+        syntax_property, syntaxcode, translate_char,
     },
     remacs_sys::{Fchar_width, Fmake_string, Fmove_to_column},
     remacs_sys::{
@@ -484,25 +484,18 @@ fn internal_self_insert(mut c: Codepoint, n: usize) -> EmacsInt {
 pub extern "C" fn keys_of_cmds() {
     let global_map = current_global_map();
 
-    unsafe {
-        let sic = CString::new("self-insert-command").unwrap();
-        initial_define_key(global_map, Ctl('I'), sic.as_ptr());
-        for n in 0x20..0x7f {
-            initial_define_key(global_map, n, sic.as_ptr());
-        }
-        for n in 0xa0..0x100 {
-            initial_define_key(global_map, n, sic.as_ptr());
-        }
-
-        let bol = CString::new("beginning-of-line").unwrap();
-        initial_define_key(global_map, Ctl('A'), bol.as_ptr());
-        let bc = CString::new("backward-char").unwrap();
-        initial_define_key(global_map, Ctl('B'), bc.as_ptr());
-        let eol = CString::new("end-of-line").unwrap();
-        initial_define_key(global_map, Ctl('E'), eol.as_ptr());
-        let fc = CString::new("forward-char").unwrap();
-        initial_define_key(global_map, Ctl('F'), fc.as_ptr());
+    initial_define_key(global_map, Ctl('I'), "self-insert-command");
+    for n in 0x20..0x7f {
+        initial_define_key(global_map, n, "self-insert-command");
     }
+    for n in 0xa0..0x100 {
+        initial_define_key(global_map, n, "self-insert-command");
+    }
+
+    initial_define_key(global_map, Ctl('A'), "beginning-of-line");
+    initial_define_key(global_map, Ctl('B'), "backward-char");
+    initial_define_key(global_map, Ctl('E'), "end-of-line");
+    initial_define_key(global_map, Ctl('F'), "forward-char");
 }
 
 #[allow(unused_doc_comments)]

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -13,6 +13,7 @@ use crate::{
     fns::{copy_alist, nreverse},
     frame::{LispFrameLiveOrSelected, LispFrameOrSelected, LispFrameRef},
     interactive::InteractiveNumericPrefix,
+    keymap::{initial_define_key, Ctl, KeyChar},
     lisp::{ExternalPtr, LispObject},
     lists::{assq, setcdr},
     marker::{marker_position_lisp, set_marker_restricted},
@@ -29,7 +30,10 @@ use crate::{
         update_mode_lines, window_list_1, window_menu_bar_p, window_scroll, window_tool_bar_p,
         windows_or_buffers_changed, wset_redisplay,
     },
-    remacs_sys::{face_id, glyph_matrix, glyph_row, pvec_type, vertical_scroll_bar_type},
+    remacs_sys::{
+        control_x_map, face_id, global_map, glyph_matrix, glyph_row, meta_map, pvec_type,
+        vertical_scroll_bar_type,
+    },
     remacs_sys::{EmacsDouble, EmacsInt, Lisp_Type, Lisp_Window},
     remacs_sys::{
         Qceiling, Qfloor, Qheader_line_format, Qleft, Qmode_line_format, Qnil, Qnone, Qright, Qt,
@@ -2056,4 +2060,15 @@ extern "C" fn rust_syms_of_window() {
     /// with the relevant frame selected.
     #[rustfmt::skip]
     defvar_lisp!(Vwindow_configuration_change_hook, "window-configuration-change-hook", Qnil);
+}
+
+#[no_mangle]
+pub extern "C" fn keys_of_window() {
+    unsafe {
+        initial_define_key(control_x_map, KeyChar('<'), "scroll-left");
+        initial_define_key(control_x_map, KeyChar('>'), "scroll-right");
+        initial_define_key(global_map, Ctl('V'), "scroll-up-command");
+        initial_define_key(meta_map, Ctl('V'), "scroll-other-window");
+        initial_define_key(meta_map, KeyChar('v'), "scroll-down-command");
+    }
 }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5278,12 +5278,14 @@ Functions running this hook are, `get-buffer-create',
   Fput (intern_c_string ("erase-buffer"), Qdisabled, Qt);
 }
 
+#ifdef IGNORE_RUST_PORT
 void
 keys_of_buffer (void)
 {
   initial_define_key (control_x_map, 'b', "switch-to-buffer");
   initial_define_key (control_x_map, 'k', "kill-buffer");
 }
+#endif
 
 extern void
 set_per_buffer_value (struct buffer *b, int offset, Lisp_Object value)

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -11460,6 +11460,7 @@ signals.  */);
   Vwhile_no_input_ignore_events = Qnil;
 }
 
+#ifdef IGNORE_RUST_PORT
 void
 keys_of_keyboard (void)
 {
@@ -11538,6 +11539,7 @@ keys_of_keyboard (void)
   initial_define_lispy_key (Vspecial_event_map, "move-frame",
 			    "handle-move-frame");
 }
+#endif /* IGNORE_RUST_PORT */
 
 /* Mark the pointers in the kboard objects.
    Called by Fgarbage_collect.  */

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -84,7 +84,7 @@ static Lisp_Object exclude_keys;
 /* Pre-allocated 2-element vector for Fcommand_remapping to use.  */
 static Lisp_Object command_remapping_vector;
 
-static Lisp_Object store_in_keymap (Lisp_Object, Lisp_Object, Lisp_Object);
+Lisp_Object store_in_keymap (Lisp_Object, Lisp_Object, Lisp_Object);
 
 static Lisp_Object define_as_prefix (Lisp_Object, Lisp_Object);
 static void describe_command (Lisp_Object, Lisp_Object);
@@ -99,6 +99,7 @@ void map_keymap_item (map_keymap_function_t, Lisp_Object, Lisp_Object, Lisp_Obje
 void map_keymap_char_table_item (Lisp_Object, Lisp_Object, Lisp_Object);
 
 
+#ifdef IGNORE_RUST_PORT
 /* This function is used for installing the standard key bindings
    at initialization time.
 
@@ -111,12 +112,15 @@ initial_define_key (Lisp_Object keymap, int key, const char *defname)
 {
   store_in_keymap (keymap, make_number (key), intern_c_string (defname));
 }
+#endif
 
+#ifdef IGNORE_RUST_PORT
 void
 initial_define_lispy_key (Lisp_Object keymap, const char *keyname, const char *defname)
 {
   store_in_keymap (keymap, intern_c_string (keyname), intern_c_string (defname));
 }
+#endif
 
 /* Look up IDX in MAP.  IDX may be any sort of event.
    Note that this does only one level of lookup; IDX must be a single
@@ -415,7 +419,7 @@ get_keyelt (Lisp_Object object, bool autoload)
     }
 }
 
-static Lisp_Object
+Lisp_Object
 store_in_keymap (Lisp_Object keymap, register Lisp_Object idx, Lisp_Object def)
 {
   /* Flush any reverse-map cache.  */
@@ -3057,9 +3061,11 @@ be preferred.  */);
   defsubr (&Sdescribe_buffer_bindings);
 }
 
+#ifdef IGNORE_RUST_PORT
 void
 keys_of_keymap (void)
 {
   initial_define_key (global_map, 033, "ESC-prefix");
   initial_define_key (global_map, Ctl ('X'), "Control-X-prefix");
 }
+#endif

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4266,6 +4266,7 @@ extern void keys_of_casefiddle (void);
 /* Defined in keyboard.c.  */
 extern bool get_input_pending (int);
 extern void process_special_events (void);
+extern Lisp_Object store_in_keymap (Lisp_Object keymap, register Lisp_Object idx, Lisp_Object def);
 
 extern void recursive_edit_unwind (Lisp_Object buffer);
 extern Lisp_Object echo_message_buffer;

--- a/src/window.c
+++ b/src/window.c
@@ -6182,6 +6182,7 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sset_window_vscroll);
 }
 
+#ifdef IGNORE_RUST_PORT
 void
 keys_of_window (void)
 {
@@ -6192,3 +6193,4 @@ keys_of_window (void)
   initial_define_key (meta_map, Ctl ('V'), "scroll-other-window");
   initial_define_key (meta_map, 'v', "scroll-down-command");
 }
+#endif


### PR DESCRIPTION
Move initially defined keybindings to Rust.

Use 'AsRef' Trait to make keybinding definition more hygienic.
Along with 'KeyChar' the need for casting is contained within
'initially_defined_key'.