### PR TITLE
inverted test when checking that the new value is in the right range

### DIFF
--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -581,7 +581,7 @@ pub unsafe extern "C" fn store_symval_forwarding(
                     prop = get(pred_sym, Qrange);
                     if let Some((min, max)) = prop.into() {
                         let args = [min, newval, max];
-                        if !newval.is_number() || leq(&args) {
+                        if !newval.is_number() || !leq(&args) {
                             wrong_range(min, max, newval);
                         }
                     } else if predicate.is_function() && call!(predicate, newval).is_nil() {


### PR DESCRIPTION
scroll-up-aggressively and scroll-down-aggressively are defined as
type fraction, so their values must be between 0.0 and 1.0
inclusive. Because the test was inverted, we were accepting only
values outside that range.

fixes #1574