### PR TITLE
Modifies Dockerfiles for current Rust toolchain

### DIFF
--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -25,6 +25,6 @@ ENV PATH "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
 RUN curl https://sh.rustup.rs -o rustup.sh && \
     sh rustup.sh \
         --default-host x86_64-unknown-linux-gnu \
-        --default-toolchain nightly-2019-02-27 -y && \
-    rustup default nightly-2019-02-27
+        --default-toolchain nightly-2020-04-07 -y && \
+    rustup default nightly-2020-04-07
 

--- a/docker/ubuntu/32bit/Dockerfile
+++ b/docker/ubuntu/32bit/Dockerfile
@@ -44,6 +44,6 @@ ENV PATH "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
 RUN curl https://sh.rustup.rs -o rustup.sh && \
     sh rustup.sh \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain nightly-2019-02-27 -y && \
-    rustup default nightly-2019-02-27
+        --default-toolchain nightly-2020-04-07 -y && \
+    rustup default nightly-2020-04-07
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -23,6 +23,6 @@ ENV PATH "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
 RUN curl https://sh.rustup.rs -o rustup.sh && \
     sh rustup.sh \
         --default-host x86_64-unknown-linux-gnu \
-        --default-toolchain nightly-2019-02-27 -y && \
-    rustup default nightly-2019-02-27
+        --default-toolchain nightly-2020-04-07 -y && \
+    rustup default nightly-2020-04-07
 

--- a/docker/ubuntu/cosmic/Dockerfile
+++ b/docker/ubuntu/cosmic/Dockerfile
@@ -25,6 +25,6 @@ ENV PATH "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
 RUN curl https://sh.rustup.rs -o rustup.sh && \
     sh rustup.sh \
         --default-host x86_64-unknown-linux-gnu \
-        --default-toolchain nightly-2019-02-27 -y && \
-    rustup default nightly-2019-02-27
+        --default-toolchain nightly-2020-04-07 -y && \
+    rustup default nightly-2020-04-07
 


### PR DESCRIPTION
This commit changes all Dockerfiles so that the nightly-2020-04-07 Rust toolchain is used since this was changed in 5b59c0f77113a1330853cff077a08f00c8f7fc88. Without this change, building via a Docker container fails due to the Rust toolchain incompatibility.