### PR TITLE
Port char-width

### DIFF
--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -3,6 +3,7 @@
 use libc::{c_uchar, ptrdiff_t};
 
 use remacs_macros::lisp_fn;
+use crate::remacs_sys::{char_width, buffer_display_table};
 
 use crate::{
     lisp::LispObject,
@@ -24,6 +25,18 @@ impl LispObject {
 /// Same as the `CHAR_HEAD_P` macro.
 pub const fn char_head_p(byte: c_uchar) -> bool {
     (byte & 0xC0) != 0x80
+}
+
+/// Return width of CHAR when displayed in the current buffer.
+/// The width is measured by how many columns it occupies on the screen.
+/// Tab is taken to occupy `tab-width' columns.
+/// usage: (char-width CHAR)
+#[lisp_fn(c_name = "char_width", name = "char-width")]
+pub fn char_width_lisp(ch: LispObject) -> EmacsInt {
+    // CHECK_CHARACTER(ch);
+    let c: EmacsInt = ch.into();
+    let width: ptrdiff_t = unsafe { char_width(c as i32, buffer_display_table()) };
+    width as EmacsInt
 }
 
 /// Decrement the buffer byte position `POS_BYTE` of the current buffer

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -89,6 +89,7 @@ extern "C" {
         depth: EmacsInt,
         sexpflag: bool,
     ) -> LispObject;
+    pub fn char_width (c: libc::c_int, dp: *mut Lisp_Char_Table) -> ptrdiff_t;
     pub fn read_minibuf(
         map: Lisp_Object,
         initial: Lisp_Object,

--- a/src/character.c
+++ b/src/character.c
@@ -95,22 +95,6 @@ char_width (int c, struct Lisp_Char_Table *dp)
 }
 
 
-DEFUN ("char-width", Fchar_width, Schar_width, 1, 1, 0,
-       doc: /* Return width of CHAR when displayed in the current buffer.
-The width is measured by how many columns it occupies on the screen.
-Tab is taken to occupy `tab-width' columns.
-usage: (char-width CHAR)  */)
-  (Lisp_Object ch)
-{
-  int c;
-  ptrdiff_t width;
-
-  CHECK_CHARACTER (ch);
-  c = XINT (ch);
-  width = char_width (c, buffer_display_table ());
-  return make_number (width);
-}
-
 /* Return width of string STR of length LEN when displayed in the
    current buffer.  The width is measured by how many columns it
    occupies on the screen.  If PRECISION > 0, return the width of
@@ -531,7 +515,6 @@ syms_of_character (void)
   staticpro (&Vchar_unify_table);
   Vchar_unify_table = Qnil;
 
-  defsubr (&Schar_width);
   defsubr (&Sstring);
   defsubr (&Sunibyte_string);
   defsubr (&Sget_byte);


### PR DESCRIPTION
Closes #1151.

The code works but to run I have to manually remove `char-width` from `bindings.rs` to avoid

```
error[E0428]: the name `char_width` is defined multiple times
     --> src/../generated/bindings.rs:28333:5
      |
28333 |     pub fn char_width(arg1: ::libc::c_int, arg2: *mut Lisp_Char_Table) -> isize;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `char_width` redefined here
      | 
     ::: src/remacs_sys.rs:92:5
      |
92    |     pub fn char_width (c: libc::c_int, dp: *mut Lisp_Char_Table) -> ptrdiff_t;
      |     -------------------------------------------------------------------------- previous definition of the value `char_width` here
      |
      = note: `char_width` must be defined only once in the value namespace of this module
```

I could use the definition in the bindings but I am not sure on what is the difference between `ptrdiff_t` and `isize` and if the use of `c_int` is fine. 