### PR TITLE
fix deceptive readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ more Emacs-y.
    IMPORTANT: Whenever the toolchain updates, you have to reinstall
    rustfmt manually.
 
-2. You will need a C compiler and toolchain. On Linux, you can do
+2. You will need Clang and a toolchain. On Linux, you can do
    something like:
 
         apt install build-essential automake clang libclang-dev


### PR DESCRIPTION
Clang is required, so it should be stated as such.

Building remacs fails due to:

```
thread 'main' panicked at 'Unable to find libclang: "couldn\'t find any valid shared libraries matching: [\'libclang.so\', \'libclang-*.so\', \'libclang.so.*\'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/valley/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.46.0/src/lib.rs:1652:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```